### PR TITLE
Add php 5.4.0 to composer.json requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "license": "MIT",
     "require": {
+        "php": ">=5.4.0",
         "mockery/mockery": "*",
         "antecedent/patchwork": "1.3.*"
     },


### PR DESCRIPTION
With PHP version in the requirements composer can handle warnings on platforms below this version. Further the 'requires' section on packagist.org gives a quick information about this.