### PR TITLE
Add support for mocking hard-coded class dependencies

### DIFF
--- a/src/Monkey.php
+++ b/src/Monkey.php
@@ -12,6 +12,7 @@ namespace Brain;
 
 use Brain\Monkey\WP\Hooks;
 use Brain\Monkey\Functions;
+use Brain\Monkey\Classes;
 use Patchwork;
 use Mockery;
 use ReflectionClass as Reflection;
@@ -69,6 +70,7 @@ class Monkey
     public static function tearDown()
     {
         Functions::__flush();
+        Classes::__flush();
         Patchwork\undoAll();
         Mockery::close();
     }
@@ -112,6 +114,18 @@ class Monkey
     public static function functions()
     {
         return new self('Brain\Monkey\Functions');
+    }
+
+    /**
+     * Returns an instance of the Brain\Monkey\Classes class
+     *
+     * We cannot use return new self() here as it leads to a "Cannot bind an instance to a static closure" error.
+     *
+     * @return \Brain\Monkey
+     */
+    public static function classes()
+    {
+        return new \Brain\Monkey\Classes();
     }
 
     /**

--- a/src/Monkey/Classes.php
+++ b/src/Monkey/Classes.php
@@ -1,0 +1,248 @@
+<?php
+/*
+ * This file is part of the Brain Monkey package.
+ *
+ * (c) Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Brain\Monkey;
+
+use Patchwork;
+use Mockery;
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * @license http://opensource.org/licenses/MIT MIT
+ * @package BrainMonkey
+ */
+class Classes
+{
+    /**
+     * @var array
+     */
+    private static $classes = [];
+
+    /**
+     * @var string Fully qualified name of the method to mock, without parenthesis
+     */
+    private $name;
+
+    /**
+     * Clean up mocked functions array.
+     */
+    public static function __flush()
+    {
+        self::$classes = [];
+    }
+
+    /**
+     * Factory method: receives the name of the class and method to mock and returns an instance of
+     * Classes where is possible to call any of the mocking functions.
+     *
+     * @param  string                 $fullyQualifiedMethodName e.g. My\Namespace\Class::methodName
+     * @return \Brain\Monkey\Classes
+     */
+    public static function when($fullyQualifiedMethodName)
+    {
+        $fullyQualifiedMethodName = self::removeTrailingParanthesis($fullyQualifiedMethodName);
+        self::check($fullyQualifiedMethodName);
+        $instance = new static();
+        $instance->name = $fullyQualifiedMethodName;
+        return $instance;
+    }
+
+    /**
+     * Returns a Mockery Expectation object, where is possible to set all the expectations, using
+     * Mockery methods.
+     *
+     * @param  string               $fullyQualifiedMethodName the name of the function to mock
+     * @return \Mockery\Expectation
+     * @see http://docs.mockery.io/en/latest/reference/expectations.html
+     */
+    public function expect($fullyQualifiedMethodName)
+    {
+        $fullyQualifiedMethodName = self::removeTrailingParanthesis($fullyQualifiedMethodName);
+        self::check($fullyQualifiedMethodName);
+        list($class, $method) = explode('::', $fullyQualifiedMethodName);
+
+        if (! isset(self::$classes[$fullyQualifiedMethodName])) {
+            self::when($fullyQualifiedMethodName);
+            $mockery = Mockery::mock($class);
+            Patchwork\replace($fullyQualifiedMethodName, function () use (&$mockery, $method) {
+                return call_user_func_array([$mockery, $method], func_get_args());
+            });
+            self::$classes[$fullyQualifiedMethodName] = $mockery;
+        }
+        /** @var \Mockery\MockInterface $mockery */
+        $mockery = self::$classes[$fullyQualifiedMethodName];
+        /** @var \Mockery\ExpectationInterface $expectation */
+        $expectation = $mockery->shouldReceive($method);
+
+        return new MockeryBridge($expectation);
+    }
+
+    /**
+     * Checks the fully qualified name of class method and throw an exception if is not valid.
+     *
+     * @param  string $fullyQualifiedMethodName
+     * @throws InvalidArgumentException if the name is invalid
+     */
+    private static function check($fullyQualifiedMethodName)
+    {
+        $names = is_string($fullyQualifiedMethodName) ? explode('\\', $fullyQualifiedMethodName) : false;
+
+        if (! $names) {
+            throw new InvalidArgumentException(sprintf("The value passed to %s is not a valid class name.",__CLASS__));
+        }
+
+        $validNamespace = function ($n) {
+            return is_string($n) && preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $n);
+        };
+
+        $canonicalMethodName = array_pop( $names );
+        if (! preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*::[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $canonicalMethodName)) {
+            throw new InvalidArgumentException("'$fullyQualifiedMethodName' is not a valid class name.");
+        }
+
+        if (array_filter($names, $validNamespace) !== $names) {
+            throw new InvalidArgumentException("'$fullyQualifiedMethodName' is not a valid namespace.");
+        }
+
+    }
+
+
+    /**
+     * Removes () from the end of a fully qualified method name if they are present.
+     *
+     * @param  string $fullyQualifiedMethodName
+     * @return string
+     */
+    private static function removeTrailingParanthesis($fullyQualifiedMethodName)
+    {
+        return preg_replace('/\(\)$/', '', $fullyQualifiedMethodName);
+    }
+
+    /**
+     * Mocks the function and makes it return an arbitrary value.
+     *
+     * @param mixed $return
+     */
+    public function justReturn($return = null)
+    {
+        Patchwork\replace($this->name, function () use ($return) {
+            return $return;
+        });
+    }
+
+    /**
+     * Mocks the function and makes it echo an arbitrary value.
+     *
+     * @param mixed $value
+     */
+    public function justEcho($value = null)
+    {
+        is_null($value) and $value = '';
+        if (! is_scalar($value) && ! (is_object($value) && method_exists($value, '__toString'))) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    "Please, use a string with %s, can't echo a var of type %s.",
+                    __METHOD__,
+                    gettype($value)
+                )
+            );
+        }
+        Patchwork\replace($this->name, function () use ($value) {
+            echo (string) $value;
+        });
+    }
+
+    /**
+     * Mocks the function making it return one of the received arguments, the first by default.
+     * Throw an exception if the function does not receive desired argument.
+     *
+     * @param int $n The position (1-based) of the argument to return
+     */
+    public function returnArg($n = 1)
+    {
+        $name = $this->name;
+        $n = $this->ensureArg($n);
+        Patchwork\replace($name, function () use ($n, $name) {
+            $count = func_num_args();
+            $n0 = $n - 1;
+            if ($count < $n0) {
+                throw new RuntimeException(
+                    "{$name} was called with {$count} params, can't return arg ".($n)."."
+                );
+            }
+
+            return func_num_args() > $n0 ? func_get_arg($n0) : null;
+        });
+    }
+
+    /**
+     * Mocks the function making it echo one of the received arguments, the first by default.
+     *
+     * @param int $n The position (1-based) of the argument to echo
+     */
+    public function echoArg($n = 1)
+    {
+        $name = $this->name;
+        $n = $this->ensureArg($n);
+        Patchwork\replace($name, function () use ($n, $name) {
+            $count = func_num_args();
+            $n0 = $n - 1;
+            if ($count < $n0) {
+                throw new RuntimeException(
+                    "{$name} was called with {$count} params, can't return arg ".($n)."."
+                );
+            }
+
+            $value = func_num_args() > $n0 ? func_get_arg($n0) : '';
+
+            if (
+                ! is_scalar($value)
+                && ! (is_object($value) && method_exists($value, '__toString'))
+            ) {
+                throw new RuntimeException(
+                    sprintf(
+                        "%s received as argument %d a %s, can't echo it.",
+                        $name,
+                        $n,
+                        gettype($value)
+                    )
+                );
+            }
+
+            echo (string) $value;
+        });
+    }
+
+    /**
+     * Mocks the function replacing it on the fly with a given callable.
+     *
+     * @param callable $callback
+     */
+    public function alias(callable $callback)
+    {
+        Patchwork\replace($this->name, $callback);
+    }
+
+    /**
+     * @param  int $n
+     * @return int
+     */
+    private function ensureArg($n)
+    {
+        if (! is_int($n) || $n < 1) {
+            throw new InvalidArgumentException(
+                "Argument number for {$this->name} must be a greater than 1 integer."
+            );
+        }
+
+        return $n;
+    }
+}

--- a/tests/boot.php
+++ b/tests/boot.php
@@ -21,3 +21,6 @@ require_once $autoload_path.'antecedent/patchwork/Patchwork.php';
 require_once $autoload_path.'phpunit/phpunit/src/Framework/Assert/Functions.php';
 require_once $autoload_path.'autoload.php';
 unset($autoload_path);
+
+//In order to mock hard-coded class dependencies we need to define those classes we wish to mock
+require_once __DIR__ . '/unit/classes.php';

--- a/tests/unit/ClassesTest.php
+++ b/tests/unit/ClassesTest.php
@@ -1,0 +1,314 @@
+<?php
+/*
+ * This file is part of the Brain Monkey package.
+ *
+ * (c) Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Brain\Monkey\Tests;
+
+use Brain\Monkey;
+use PHPUnit_Framework_TestCase;
+use Brain\Monkey\Classes;
+use Mockery;
+
+/**
+ * @license http://opensource.org/licenses/MIT MIT
+ * @package BrainMonkey
+ */
+class ClassesTest extends PHPUnit_Framework_TestCase
+{
+    protected function tearDown()
+    {
+        Monkey::tearDown();
+    }
+
+    /**
+     * @dataProvider invalidMethodNamesProvider
+     * @expectedException \InvalidArgumentException
+     */
+    public function testClassesFailIfInvalidMethodName($fullyQualifiedMethodName)
+    {
+        Classes::when($fullyQualifiedMethodName)->justReturn('Cool!');
+    }
+
+    public function invalidMethodNamesProvider(){
+        return array(
+          'semicolon not colon' => array( 'MyClass:;invalid' ),
+          'too many colons' => array( 'MyClass:::invalid' ),
+          'contains space' => array( 'My Class::invalid' ),
+          'class starts with number' => array( '123MyClass::invalid' ),
+          'method starts with number' => array( 'MyClass::123invalid' ),
+        );
+    }
+
+    public function testClassesWithParanthesis()
+    {
+        Classes::when('MyClass::returnSomething()')->justReturn('Cool!');
+    }
+
+    public function testClassesFunction()
+    {
+        Monkey::classes()->when('MyClass::returnSomething')->justReturn('A!');
+        Monkey::classes()->when('MyClass::returnSomethingElse')->returnArg();
+        Monkey::classes()->when('MyClass::aliasMe')->alias('str_rot13');
+        Monkey::classes()->expect('MyClass::doSomething')->atMost()->twice()->with(true)->andReturn('D!');
+        Monkey::classes()->expect('MyClass::doSomething')->atMost()->twice()->with(false)->andReturn('E!');
+
+        $myClass = new \MyClass();
+        assertSame('A!',$myClass->returnSomething());
+        assertSame('B!',$myClass->returnSomethingElse('B!'));
+        assertSame('C!',$myClass->aliasMe('P!'));
+        assertSame('D!',$myClass->doSomething(true));
+        assertSame('D!',$myClass->doSomething(true));
+        assertSame('E!',$myClass->doSomething(false));
+    }
+
+    public function testJustReturn()
+    {
+
+        Classes::when('MyClass::returnSomething()')->justReturn('Cool!');
+        Classes::when('MyClass::returnNull()')->justReturn();
+        $myClass = new \MyClass();
+        assertSame('Cool!',$myClass->returnSomething());
+        assertNull($myClass->returnNull());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testPassThroughFailIfBadArg()
+    {
+        Classes::when('MyClass::returnSomething')->returnArg('miserably');
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testPassThroughFailIfNotReceived()
+    {
+
+        Classes::when('MyClass::returnSomething')->returnArg(5);
+        $myClass = new \MyClass();
+        $myClass->returnSomething();
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     */
+    public function testAlias()
+    {
+
+        Classes::when('Villian::greetSpy')->alias(function ($title, $name) {
+            return "{$title} {$name}, I've been expecting you.";
+        });
+        $blofeld  = new \Villian();
+        assertSame('Mr Bond, I\'ve been expecting you.', $blofeld->greetSpy('Mr', 'Bond'));
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testExpectFailIfShouldReceive()
+    {
+        Classes::expect('MyClass::returnSomething')->shouldReceive('foo');
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     */
+    public function testExpectWith()
+    {
+
+        Classes::expect('MyClass::returnSomething')->with('test');
+
+        $myClass = new \MyClass();
+        $myClass->returnSomething( 'test' );
+    }
+
+
+    public function testExpectAndReturn()
+    {
+        Classes::expect('MyClass::returnSomething')->andReturn('I was called');
+        $myClass = new \MyClass();
+        assertSame('I was called', $myClass->returnSomething());
+    }
+
+    public function testExpectNumberAndReturn()
+    {
+        Classes::expect('MyClass::returnSomething')->twice()->andReturn('first', 'second');
+        $myClass = new \MyClass();
+        assertSame('first', $myClass->returnSomething());
+        assertSame('second', $myClass->returnSomething());
+    }
+
+    public function testExpectComplete()
+    {
+        Classes::expect('MyClass::returnSomething')
+            ->once()
+            ->with(200, Mockery::anyOf(800, 300), Mockery::type('string'))
+            ->andReturnUsing(function ($a, $b, $c) {
+                return (($a + $b) * 2).$c;
+            });
+
+        $myClass = new \MyClass();
+        assertSame("1000 times cool!", $myClass->returnSomething(200, 300, ' times cool!'));
+    }
+
+
+    public function testNamespacedClasses()
+    {
+
+        Classes::when('foo\\bar\\MyClass::returnSomething')->justReturn('namespaced');
+        Classes::when('MyClass::returnSomething')->justReturn('not namespaced');
+
+        $myGlobalClass = new \MyClass();
+        $myNameSpacedClass = new \foo\bar\MyClass();
+
+        assertSame('not namespaced', $myGlobalClass->returnSomething());
+        assertSame('namespaced', $myNameSpacedClass->returnSomething());
+    }
+
+    public function testSameFunctionDifferentArguments()
+    {
+        Classes::expect('MyClass::returnSomething')
+            ->with(true)
+            ->once()
+            ->ordered()
+            ->andReturn('First!');
+
+        Classes::expect('MyClass::returnSomething')
+            ->with(false)
+            ->once()
+            ->ordered()
+            ->andReturn('Second!');
+
+        $myClass = new \MyClass();
+        assertSame('First!', $myClass->returnSomething(true));
+        assertSame('Second!', $myClass->returnSomething(false));
+    }
+
+    public function testJustEcho()
+    {
+
+        Classes::when('MyClass::echoSomething')->justEcho('Cool!');
+        $this->expectOutputString('Cool!');
+        $myClass = new \MyClass();
+        $myClass->echoSomething();
+    }
+
+    public function testJustEchoEmptyString()
+    {
+
+        Classes::when('MyClass::echoSomething')->justEcho();
+        $this->expectOutputString('');
+        $myClass = new \MyClass();
+        $myClass->echoSomething();
+    }
+
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /can't echo a var of type array/
+     */
+    public function testJustEchoNotScalar()
+    {
+
+        Classes::when('MyClass::echoSomething')->justEcho(['foo']);
+    }
+
+    public function testJustEchoToStringObject()
+    {
+
+        $toString = Mockery::mock();
+        $toString->shouldReceive('__toString')->andReturn('Cool!');
+
+        Classes::when('MyClass::echoSomething')->justEcho($toString);
+        $this->expectOutputString('Cool!');
+        $myClass = new \MyClass();
+        $myClass->echoSomething($toString);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /can't echo a var of type object/
+     */
+    public function testJustEchoObject()
+    {
+
+        Classes::when('MyClass::echoSomething')->justEcho(new \stdClass());
+        $myClass = new \MyClass();
+        $myClass->echoSomething();
+    }
+
+    public function testEchoArg()
+    {
+
+        Classes::when('MyClass::echoSomething')->echoArg(2);
+        $this->expectOutputString('Cool!');
+        $myClass = new \MyClass();
+        $myClass->echoSomething(1, 'Cool!');
+    }
+
+    public function testEchoArgFirst()
+    {
+
+        Classes::when('MyClass::echoSomething')->echoArg();
+        $this->expectOutputString('Cool!');
+        $myClass = new \MyClass();
+        $myClass->echoSomething('Cool!');
+    }
+
+    public function testEchoArgScalar()
+    {
+
+        Classes::when('MyClass::echoSomething')->echoArg();
+        $this->expectOutputString('1');
+        $myClass = new \MyClass();
+        $myClass->echoSomething(1);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessageRegExp /can't echo it/
+     */
+    public function testEchoArgNotScalar()
+    {
+
+        Classes::when('MyClass::echoSomething')->echoArg(1);
+        $myClass = new \MyClass();
+        $myClass->echoSomething(['foo']);
+    }
+
+    public function testEchoArgToStringObject()
+    {
+
+        $toString = Mockery::mock();
+        $toString->shouldReceive('__toString')->andReturn('Cool!');
+
+        Classes::when('MyClass::echoSomething')->echoArg(1);
+        $this->expectOutputString('Cool!');
+        $myClass = new \MyClass();
+        $myClass->echoSomething($toString);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessageRegExp /can't echo it/
+     */
+    public function testEchoArgObject()
+    {
+
+        Classes::when('MyClass::echoSomething')->echoArg(1);
+        $myClass = new \MyClass();
+        $myClass->echoSomething(new \stdClass());
+    }
+
+}

--- a/tests/unit/ClassesTest.php
+++ b/tests/unit/ClassesTest.php
@@ -176,7 +176,7 @@ class ClassesTest extends PHPUnit_Framework_TestCase
         assertSame('namespaced', $myNameSpacedClass->returnSomething());
     }
 
-    public function testSameFunctionDifferentArguments()
+    public function testSameMethodDifferentArguments()
     {
         Classes::expect('MyClass::returnSomething')
             ->with(true)

--- a/tests/unit/classes.php
+++ b/tests/unit/classes.php
@@ -1,0 +1,25 @@
+<?php
+namespace { // global code
+    class MyClass
+    {
+        function returnSomething(){}
+        function returnSomethingElse(){}
+        function doSomething(){}
+        function echoSomething(){}
+        function aliasMe(){}
+        function notMocked(){}
+        function returnNull(){}
+    }
+    class Villian
+    {
+        function greetSpy(){}
+    }
+}
+
+namespace foo\bar {
+    class MyClass
+    {
+        function returnSomething(){}
+        function echoSomething(){}
+    }
+}


### PR DESCRIPTION
The use case for this is as follows. I have a `Query` class which just wraps `WP_Query`, and gives it a nice locked-down interface for creating a query:

```
class Query {
     private $query = array();
     ...
     public function between ( DateRange $range ) {
        //modified $this->query array
     } 
     public function postedBy( WP_User $user ) {
        //modified $this->query array
     }
     ...
     public function getPosts() {
        $wp_query = new WP_Query();
        $wp_query->query( $this->query );
        return $wp_query->posts;
     }

 }
```

To test my `Query` I need to mock `WP_Query()`. Of course dependency injection is an option, but in this instance it just seems messy, and in any case, `WP_Query` doesn't implement an interface.

You can use Patchwork's overload feature, but this provides consistency with the rest of the BrainMonkey package. 

There's a slight difference in how the API is implemented: `Classes::expect()` is not declared as static. Doing so resulted in a _Cannot bind an instance to a static closure_ error from Patchwork. Also, classes to be mocked have to be defined.
