### PR TITLE
PHP 7.4 compatibility fix / implode argument order

### DIFF
--- a/src/Name/ClosureStringForm.php
+++ b/src/Name/ClosureStringForm.php
@@ -121,6 +121,6 @@ final class ClosureStringForm
 
         $name = $static ? 'static function (' : 'function (';
 
-        return $name.implode($arguments, ', ').')';
+        return $name.implode(', ', $arguments).')';
     }
 }


### PR DESCRIPTION
`implode()` takes two parameters, `$glue` and `$pieces`.
For historical reasons, `implode()` accepted these parameters in either order, though it was recommended to use the documented argument order of `implode( $glue, $pieces )`.

PHP 7.4 deprecates the tolerance for passing the parameters for `implode()` in reverse order.
PHP 8.0 is expected to remove the tolerance for this completely.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix
* https://php.net/manual/en/function.implode.php