### PR TITLE
PHPCompatibility fix: `ReflectionType::__toString()` is deprecated

### DIFF
--- a/src/Name/ClosureParamStringForm.php
+++ b/src/Name/ClosureParamStringForm.php
@@ -73,8 +73,13 @@ class ClosureParamStringForm
     public static function fromReflectionParameter(\ReflectionParameter $parameter)
     {
         $type = '';
-        if (PHP_MAJOR_VERSION >= 7) {
-            $type = $parameter->hasType() ? ltrim($parameter->getType(), '\\') : '';
+        if (PHP_MAJOR_VERSION >= 7 && $parameter->hasType()) {
+            $type = $parameter->getType();
+            if (isset($type) && $type instanceof ReflectionNamedType) {
+                $type = $type->getName();
+            }
+
+            $type = ltrim($type, '\\');
         }
 
         return new static($parameter->getName(), $type, $parameter->isVariadic());


### PR DESCRIPTION
`ReflectionType::__toString()` has been deprecated as of PHP 7.1, though PHP only started throwing warnings about this in PHP 7.4.

This PR changes the parameter type retrieval code in a way that it is compatible with all PHP 7 versions.

Also see:
* https://www.php.net/manual/en/reflectionparameter.gettype.php