### PR TITLE
Travis: various tweaks for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ php:
   - 7.3
 
 before_script:
-  - travis_retry composer self-update
-  - travis_retry composer update --no-interaction --prefer-source  --classmap-authoritative
+  # Speed up build time by disabling Xdebug.
+  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+
+  - travis_retry composer install --no-interaction --prefer-source  --classmap-authoritative
 
 script:
-  - vendor/bin/phpunit
+  - vendor/bin/phpunit --no-coverage


### PR DESCRIPTION
* If the test coverage is not being used in the CI process, you may as well make the unit tests faster by not generating it at all.
* And if test coverage is not being generated, there is no need for Xdebug, so disabling it.
    This will make the Composer install faster too.
* All the Travis PHP images nowadays already include the `composer self-update` command, so no need to redo it.
* And as the repo does not have a `composer.lock` file commited, there is no need to do a `composer update`. Just running `composer install` will do.