### PR TITLE
Tests: minor clean up

### DIFF
--- a/tests/cases/functional/ActionsTest.php
+++ b/tests/cases/functional/ActionsTest.php
@@ -11,13 +11,14 @@
 namespace Brain\Monkey\Tests\Functional;
 
 use Brain\Monkey;
+use Brain\Monkey\Tests\FunctionalTestCase;
 
 /**
  * @author  Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
  * @license http://opensource.org/licenses/MIT MIT
  * @package BrainMonkey
  */
-class ActionsTest extends Monkey\Tests\FunctionalTestCase
+class ActionsTest extends FunctionalTestCase
 {
     public function testExpectAdded()
     {

--- a/tests/cases/functional/FiltersTest.php
+++ b/tests/cases/functional/FiltersTest.php
@@ -11,13 +11,14 @@
 namespace Brain\Monkey\Tests\Functional;
 
 use Brain\Monkey;
+use Brain\Monkey\Tests\FunctionalTestCase;
 
 /**
  * @author  Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
  * @license http://opensource.org/licenses/MIT MIT
  * @package BrainMonkey
  */
-class FiltersTest extends Monkey\Tests\FunctionalTestCase
+class FiltersTest extends FunctionalTestCase
 {
     public function testExpectAdded()
     {

--- a/tests/cases/functional/FunctionsTest.php
+++ b/tests/cases/functional/FunctionsTest.php
@@ -11,13 +11,14 @@
 namespace Brain\Monkey\Tests\Functional;
 
 use Brain\Monkey;
+use Brain\Monkey\Tests\FunctionalTestCase;
 
 /**
  * @author  Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
  * @license http://opensource.org/licenses/MIT MIT
  * @package BrainMonkey
  */
-class FunctionsTest extends Monkey\Tests\FunctionalTestCase
+class FunctionsTest extends FunctionalTestCase
 {
     public function testWhen()
     {

--- a/tests/cases/unit/Api/AddActionTest.php
+++ b/tests/cases/unit/Api/AddActionTest.php
@@ -12,6 +12,7 @@ namespace Brain\Monkey\Tests\Unit\Api;
 
 use Brain\Monkey;
 use Brain\Monkey\Actions;
+use Brain\Monkey\Tests\UnitTestCase;
 use Mockery\Exception\InvalidCountException;
 
 /**
@@ -19,7 +20,7 @@ use Mockery\Exception\InvalidCountException;
  * @license http://opensource.org/licenses/MIT MIT
  * @package BrainMonkey
  */
-class AddActionTest extends Monkey\Tests\UnitTestCase
+class AddActionTest extends UnitTestCase
 {
     public function testAddNull()
     {

--- a/tests/cases/unit/Api/DoActionTest.php
+++ b/tests/cases/unit/Api/DoActionTest.php
@@ -12,6 +12,7 @@ namespace Brain\Monkey\Tests\Unit\Api;
 
 use Brain\Monkey;
 use Brain\Monkey\Actions;
+use Brain\Monkey\Tests\UnitTestCase;
 use Mockery\Exception\InvalidCountException;
 
 /**
@@ -19,7 +20,7 @@ use Mockery\Exception\InvalidCountException;
  * @license http://opensource.org/licenses/MIT MIT
  * @package BrainMonkey
  */
-class DoActionTest extends Monkey\Tests\UnitTestCase
+class DoActionTest extends UnitTestCase
 {
 
     public function testDoNull()


### PR DESCRIPTION
Add import `use` statements for the unit test classes being extended.