### PR TITLE
PHPUnit: add bootstrap configuration directive

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"


### PR DESCRIPTION
The way the unit tests are setup, the Composer `vendor/autoload.php` file is a prerequisite for them to run, so this should be made explicit in the configuration file.