### PR TITLE
Tests: make testsuite compatible with more recent PHPUnit versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "antecedent/patchwork": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7.9"
+        "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,25 @@
+<?php # -*- coding: utf-8 -*-
+/*
+ * This file is part of the BrainMonkey package.
+ *
+ * (c) Juliette Reinders Folmer
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$autoload = realpath(__DIR__ . '/../vendor/autoload.php');
+
+if (file_exists($autoload)) {
+    require_once $autoload;
+} else {
+    echo 'Autoload file not found. Please run `composer install`.';
+    die(1);
+}
+
+// PHPUnit cross version compatibility.
+if (class_exists('PHPUnit_Framework_Error') === true
+    && class_exists('PHPUnit\Framework\Error\Error') === false
+) {
+    class_alias('PHPUnit_Framework_Error', 'PHPUnit\Framework\Error\Error');
+}

--- a/tests/cases/unit/Api/FunctionsTest.php
+++ b/tests/cases/unit/Api/FunctionsTest.php
@@ -13,6 +13,7 @@ namespace Brain\Monkey\Tests\Unit\Api;
 use Brain\Monkey\Functions;
 use Brain\Monkey\Tests\UnitTestCase;
 use Mockery\Exception\InvalidCountException;
+use PHPUnit\Framework\Error\Error as PHPUnit_Error;
 
 /**
  * @author  Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
@@ -148,7 +149,7 @@ class FunctionsTest extends UnitTestCase
 
     public function testUndefinedFunctionTriggerErrorRightAfterDefinition()
     {
-        $this->expectException(\PHPUnit_Framework_Error::class);
+        $this->expectException(PHPUnit_Error::class);
         Functions\when('since_i_am_not_defined_i_will_trigger_error');
         $this->expectExceptionMessageRegExp('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
         /** @noinspection PhpUndefinedFunctionInspection */
@@ -168,7 +169,7 @@ class FunctionsTest extends UnitTestCase
      */
     public function testSurvivedFunctionStillTriggerError()
     {
-        $this->expectException(\PHPUnit_Framework_Error::class);
+        $this->expectException(PHPUnit_Error::class);
         $this->expectExceptionMessageRegExp('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
         /** @noinspection PhpUndefinedFunctionInspection */
         since_i_am_not_defined_i_will_trigger_error();
@@ -189,7 +190,7 @@ class FunctionsTest extends UnitTestCase
      */
     public function testSurvivedFunctionStillTriggerErrorAfterBeingMocked()
     {
-        $this->expectException(\PHPUnit_Framework_Error::class);
+        $this->expectException(PHPUnit_Error::class);
         $this->expectExceptionMessageRegExp('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
         /** @noinspection PhpUndefinedFunctionInspection */
         since_i_am_not_defined_i_will_trigger_error();

--- a/tests/src/FunctionalTestCase.php
+++ b/tests/src/FunctionalTestCase.php
@@ -11,13 +11,14 @@
 namespace Brain\Monkey\Tests;
 
 use Brain\Monkey;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author  Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
  * @package BrainMonkey
  * @license http://opensource.org/licenses/MIT MIT
  */
-class FunctionalTestCase extends \PHPUnit_Framework_TestCase
+class FunctionalTestCase extends TestCase
 {
     protected function setUp()
     {

--- a/tests/src/UnitTestCase.php
+++ b/tests/src/UnitTestCase.php
@@ -11,13 +11,14 @@
 namespace Brain\Monkey\Tests;
 
 use Brain\Monkey;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author  Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
  * @package BrainMonkey
  * @license http://opensource.org/licenses/MIT MIT
  */
-class UnitTestCase extends \PHPUnit_Framework_TestCase
+class UnitTestCase extends TestCase
 {
     private $expect_mockery_exception = null;
 


### PR DESCRIPTION
* PHPUnit 6 changed the PHPUnit classes to namespaced.
    As of PHPUnit 5.4 a compatibility layer is available which aliases most of the old names to the new names.
    As the previously required PHPUnit version was already higher than PHPUnit 5.4, switching over to the new class names makes the tests compatible with both PHPUnit 5 as well as 6.
* Unfortunately, the PHPUnit `PHPUnit_Framework_Error` class was not included in the compatibility layer, so to still be able to use that class cross-version, a `class_alias`-es needs to be put in place.
    This is done by adding a PHPUnit `bootstrap.php` file, adding that file to the `phpunit.xml.dist` config and having that file require the Composer `autoload.php` file as well as create the necessary class alias for the PHPUnit class.
    _As this BrainMonkey native bootstrap file is now needed, this PR supersedes PR #59 which I previously opened._
* As of PHPUnit 6, PHPUnit by default will report on "useless tests", i.e. tests which don't invoke any of the PHPUnit native assertions.
    As BrainMonkey has its own assertions, this gives a lot of unnecessary noise.
    The `beStrictAboutTestsThatDoNotTestAnything="false"` addition to the configuration file turns this off.
* Validated the `phpunit.xml.dist` file against the current XSD file and found it compliant.

Note: the current version of PHPUnit is 8.4.1.
This PR explicitly does not make the unit tests compatible with PHPUnit 8.
PHPUnit 8 has a minimum PHP requirement of PHP 7.2 and uses the `void` return type declaration which was only introduced in PHP 7.1.
As BrainMonkey has a minimum PHP requirement of 5.6 and PHPUnit 7 still works fine on PHP 7.4, making the unit tests compatible with PHPUnit 8 is for later.