### PR TITLE
Travis: test against PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - "7.4snapshot"
 
 before_script:
   - travis_retry composer self-update


### PR DESCRIPTION
While Travis (still) doesn't have an official PHP 7.4 image, this unofficial image made available by one of the PHP core contributors is up-to-date and allows you to test against PHP 7.4.

As PHP 7.4 is supposed to be released by end of November, I'm not setting `allow_failures` as the code really should be compatible before that time, especially **_as other software is depending on BrainMonkey to be able to assess their own PHP 7.4 readiness..._**

The build for this PR won't pass until PR #55 and PR #61 have both been merged.

A passing build containing this commit + the commits of the above mentioned PRs can be found here: https://travis-ci.org/jrfnl/BrainMonkey/builds/596457760