### PR TITLE
Travis: add task to lint the PHP files against all supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
   - travis_retry composer update --no-interaction --prefer-source  --classmap-authoritative
 
 script:
+  - composer lint
   - vendor/bin/phpunit --coverage-clover=coverage.xml
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,9 @@
         "antecedent/patchwork": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0"
+        "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0",
+        "jakub-onderka/php-parallel-lint": "^1.0",
+        "jakub-onderka/php-console-highlighter": "^0.4"
     },
     "autoload": {
         "psr-4": {
@@ -62,5 +64,10 @@
             "dev-version/1": "1.x-dev",
             "dev-master": "2.0.x-dev"
         }
+    },
+    "scripts" : {
+        "lint": [
+            "@php ./vendor/jakub-onderka/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+        ]
     }
 }


### PR DESCRIPTION
* Includes installing the [PHP-Parallel-Lint](https://github.com/JakubOnderka/PHP-Parallel-Lint) package to allow for fast linting and comprehensive error reporting.
* Includes installing the PHP console highlighter to enable syntax highlighting of the reporting by PHP-Parallel-Lint.
* Includes adding a Composer script to run the command easily with the correct command-line arguments.
    Note: using `@php` will make sure that the script is triggered with the same PHP version as Composer is using (if different from the system default PHP version).
    Note: calling the actual `parallel-lint` script directly instead of via the `vendor/bin` will allow for the script to run cross-platform as otherwise devs on Windows may run into errors.

Related to #63