### PR TITLE
Travis: add task to check the PHP files for cross-version compatibility issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,22 @@ php:
   - 7.3
   - "7.4snapshot"
 
+stages:
+  - name: analyze
+  - name: test
+
+jobs:
+  fast_finish: true
+  include:
+    #### CODE ANALYSIS ####
+    # Separate stage for code analysis tools which give the same results cross-version,
+    # so only need to run on one PHP version per build.
+    - stage: analyze
+      php: 7.3
+      script:
+        - composer phpcompat
+      after_success: skip
+
 before_script:
   - travis_retry composer update --no-interaction --prefer-source  --classmap-authoritative
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,9 @@
         "antecedent/patchwork": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0"
+        "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0",
+        "phpcompatibility/php-compatibility": "^9.3.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4"
     },
     "autoload": {
         "psr-4": {
@@ -62,5 +64,10 @@
             "dev-version/1": "1.x-dev",
             "dev-master": "2.0.x-dev"
         }
+    },
+    "scripts" : {
+        "phpcompat": [
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -p . --standard=PHPCompatibility --ignore=*/vendor/* --extensions=php --basepath=./ --runtime-set testVersion 5.6-"
+        ]
     }
 }

--- a/inc/wp-helper-functions.php
+++ b/inc/wp-helper-functions.php
@@ -10,6 +10,11 @@
  * @author  Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
  * @license http://opensource.org/licenses/MIT MIT
  * @package BrainMonkey
+ *
+ * As the functions in this file are a compatibility layer for WordPress, the same
+ * function names should be used as are currently used by WordPress.
+ * This cannot be changed at this time.
+ * @phpcs:disable PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore
  */
 
 if ( ! function_exists('__return_true')) {


### PR DESCRIPTION
* Installs the [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) package to check code for cross-version compatibility using static analysis based on [PHP_CodeSniffer](https://github.com/squizlabs/php_codesniffer/).
* Includes installing the [DealerDirect Composer PHPCS plugin](https://github.com/Dealerdirect/phpcodesniffer-composer-installer/) which will automatically handle registering the external PHPCompatibility standard with PHP_CodeSniffer.
* Includes adding a Composer script to run the command easily with the correct command-line arguments.
    Alternatively, the configuration could be setup in a `phpcs.xml.dist` file which could at a later time be expanded to also include code style rules.
    _**Let me know if you'd prefer that.**_
    - Note: using `@php` will make sure that the script is triggered with the same PHP version as Composer is using (if different from the system default PHP version).
    - Note: calling the actual `phpcs` script directly instead of via the `vendor/bin` will allow for the script to run cross-platform as otherwise devs on Windows may run into errors.
* Includes adding the task in a separate stage to the Travis script.
    The PHPCompatibility scanner will give the same results on all supported PHP version, so there is no need to run it on all builds, only once will do.
    Using stages allows for running the task in isolation using a different `script`.
    Ref: https://docs.travis-ci.com/user/build-stages/
* Includes adding one whitelist comment to ignore a specific issue for one particular file.
    The issue being ignored is that the double underscore prefix for function names is reserved by PHP itself and should not be used in user-land code.
    As this is a compatibility layer for WP and WP still uses those function names, this is not an issue for BrainMonkey to solve until WP changes those function names.
    Also, as - at this time - PHP does not use those specific function names yet, in practice this currently will not give any cross-version compatibility issues.

Related to #63