### PR TITLE
Add function stubs for deprecated hook calls

### DIFF
--- a/inc/wp-hook-functions.php
+++ b/inc/wp-hook-functions.php
@@ -56,6 +56,15 @@ if ( ! function_exists('do_action_ref_array')) {
     }
 }
 
+if ( ! function_exists('do_action_deprecated')) {
+    function do_action_deprecated($action, array $args, $version, $replacement, $message = null)
+    {
+        $container = Monkey\Container::instance();
+        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::ACTIONS, $action, $args);
+        $container->hookExpectationExecutor()->executeDoAction($action, $args);
+    }
+}
+
 if ( ! function_exists('apply_filters')) {
     function apply_filters($filter, ...$args)
     {
@@ -68,6 +77,16 @@ if ( ! function_exists('apply_filters')) {
 
 if ( ! function_exists('apply_filters_ref_array')) {
     function apply_filters_ref_array($filter, array $args)
+    {
+        $container = Monkey\Container::instance();
+        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::FILTERS, $filter, $args);
+
+        return $container->hookExpectationExecutor()->executeApplyFilters($filter, $args);
+    }
+}
+
+if ( ! function_exists('apply_filters_deprecated')) {
+    function apply_filters_deprecated($filter, array $args, $version, $replacement, $message = null)
     {
         $container = Monkey\Container::instance();
         $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::FILTERS, $filter, $args);

--- a/tests/cases/functional/ActionsTest.php
+++ b/tests/cases/functional/ActionsTest.php
@@ -103,4 +103,38 @@ class ActionsTest extends FunctionalTestCase
 
         do_action('my_hook', 'Hello', 'World');
     }
+
+    public function testExpectAppliedThenDoneDeprecated()
+    {
+        $this->expectOutputString('Hello World');
+
+        /** @var callable|null $on_my_hook */
+        $on_my_hook = null;
+
+        Monkey\Actions\expectAdded('my_hook')
+            ->with(\Mockery::type('callable'), \Mockery::type('int'), 2)
+            ->whenHappen(
+                static function (callable $callback) use (&$on_my_hook) {
+                    $on_my_hook = $callback;
+                }
+            );
+
+        Monkey\Actions\expectDone('my_hook')
+            ->whenHappen(
+                static function (...$args) use (&$on_my_hook) {
+                    $on_my_hook(...$args);
+                }
+            );
+
+        add_action(
+            'my_hook',
+            function ($a, $b) {
+                echo "{$a} {$b}";
+            },
+            1,
+            2
+        );
+
+        do_action_deprecated('my_hook', array('Hello', 'World'), 'x.x.x.', 'Replacement');
+    }
 }

--- a/tests/cases/functional/FiltersTest.php
+++ b/tests/cases/functional/FiltersTest.php
@@ -100,4 +100,41 @@ class FiltersTest extends FunctionalTestCase
 
         static::assertSame('HELLO WORLD', $hello);
     }
+
+    public function testExpectAppliedThenDoneDeprecated()
+    {
+        /** @var callable|null $on_my_hook */
+        $on_my_hook = null;
+
+        Monkey\Filters\expectAdded('my_hook')
+            ->with(\Mockery::type('callable'), 1, 2)
+            ->once()
+            ->whenHappen(
+                static function (callable $callback) use (&$on_my_hook) {
+                    $on_my_hook = $callback;
+                }
+            );
+
+        Monkey\Filters\expectApplied('my_hook')
+            ->once()
+            ->with(\Mockery::type('string'), \Mockery::type('string'))
+            ->andReturnUsing(
+                static function ($a, $b) use (&$on_my_hook) {
+                    return $on_my_hook($a, $b);
+                }
+            );
+
+        add_filter(
+            'my_hook',
+            function ($a, $b) {
+                return strtoupper("{$a} {$b}");
+            },
+            1,
+            2
+        );
+
+        $hello = apply_filters_deprecated('my_hook', array('Hello', 'World'), 'x.x.x', 'Replacement');
+
+        static::assertSame('HELLO WORLD', $hello);
+    }
 }


### PR DESCRIPTION
Function set completeness.

This allows for calls to `do_action_deprecated()` and `apply_filters_deprecated()` to be registered and expectations set for these.

This does not include testing that the deprecation notices are being thrown correctly, but as that's WP Core functionality, that shouldn't be tested here anyway.

Refs:
* https://developer.wordpress.org/reference/functions/do_action_deprecated/
* https://developer.wordpress.org/reference/functions/apply_filters_deprecated/