### PR TITLE
Composer: update PHPCS Composer plugin dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0",
         "phpcompatibility/php-compatibility": "^9.3.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || ^0.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The DealerDirect Composer plugin has released version `0.7.0` a little while ago.
This new version includes support for Composer 2.0.0 (expected soon).

As Composer treats minors < 1.0 as majors, updating to this version requires an update to the `composer.json` requirements.

> For pre-1.0 versions it also acts with safety in mind and treats `^0.3` as `>=0.3.0 <0.4.0`.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.7.0
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.6.0
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-