### PR TITLE
Tests: PHPUnit cross-version compatibility + test against PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/
 website/
 couscous-theme/
 couscous.*
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - "7.4snapshot"
+  - 7.4
+  - "nightly"
 
 stages:
   - name: analyze

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "antecedent/patchwork": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0",
+        "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "phpcompatibility/php-compatibility": "^9.3.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || ^0.7"
     },

--- a/tests/cases/unit/Api/FunctionsTest.php
+++ b/tests/cases/unit/Api/FunctionsTest.php
@@ -149,7 +149,7 @@ class FunctionsTest extends UnitTestCase
 
     public function testUndefinedFunctionTriggerErrorRightAfterDefinition()
     {
-        $this->expectException(PHPUnit_Error::class);
+        $this->expectErrorExceptionHelper();
         Functions\when('since_i_am_not_defined_i_will_trigger_error');
         $this->expectExceptionMsgRegexHelper('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
         /** @noinspection PhpUndefinedFunctionInspection */
@@ -169,7 +169,7 @@ class FunctionsTest extends UnitTestCase
      */
     public function testSurvivedFunctionStillTriggerError()
     {
-        $this->expectException(PHPUnit_Error::class);
+        $this->expectErrorExceptionHelper();
         $this->expectExceptionMsgRegexHelper('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
         /** @noinspection PhpUndefinedFunctionInspection */
         since_i_am_not_defined_i_will_trigger_error();
@@ -190,7 +190,7 @@ class FunctionsTest extends UnitTestCase
      */
     public function testSurvivedFunctionStillTriggerErrorAfterBeingMocked()
     {
-        $this->expectException(PHPUnit_Error::class);
+        $this->expectErrorExceptionHelper();
         $this->expectExceptionMsgRegexHelper('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
         /** @noinspection PhpUndefinedFunctionInspection */
         since_i_am_not_defined_i_will_trigger_error();
@@ -385,5 +385,17 @@ class FunctionsTest extends UnitTestCase
 
         // PHPUnit < 8.4.
         $this->expectExceptionMessageRegExp($msgRegex);
+    }
+
+    protected function expectErrorExceptionHelper()
+    {
+        if (method_exists($this, 'expectError')) {
+            // PHPUnit 8.4+.
+            $this->expectError();
+            return;
+        }
+
+        // PHPUnit < 8.4.
+        $this->expectException(PHPUnit_Error::class);
     }
 }

--- a/tests/cases/unit/Api/FunctionsTest.php
+++ b/tests/cases/unit/Api/FunctionsTest.php
@@ -151,7 +151,7 @@ class FunctionsTest extends UnitTestCase
     {
         $this->expectException(PHPUnit_Error::class);
         Functions\when('since_i_am_not_defined_i_will_trigger_error');
-        $this->expectExceptionMessageRegExp('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
+        $this->expectExceptionMsgRegexHelper('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
         /** @noinspection PhpUndefinedFunctionInspection */
         since_i_am_not_defined_i_will_trigger_error();
     }
@@ -170,7 +170,7 @@ class FunctionsTest extends UnitTestCase
     public function testSurvivedFunctionStillTriggerError()
     {
         $this->expectException(PHPUnit_Error::class);
-        $this->expectExceptionMessageRegExp('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
+        $this->expectExceptionMsgRegexHelper('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
         /** @noinspection PhpUndefinedFunctionInspection */
         since_i_am_not_defined_i_will_trigger_error();
     }
@@ -191,7 +191,7 @@ class FunctionsTest extends UnitTestCase
     public function testSurvivedFunctionStillTriggerErrorAfterBeingMocked()
     {
         $this->expectException(PHPUnit_Error::class);
-        $this->expectExceptionMessageRegExp('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
+        $this->expectExceptionMsgRegexHelper('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
         /** @noinspection PhpUndefinedFunctionInspection */
         since_i_am_not_defined_i_will_trigger_error();
     }
@@ -373,5 +373,17 @@ class FunctionsTest extends UnitTestCase
 
         static::assertSame("hello, \\'world\\'", esc_sql("hello, 'world'"));
         static::assertSame('<b>hello world</b>', esc_sql('<b>hello world</b>'));
+    }
+
+    protected function expectExceptionMsgRegexHelper($msgRegex)
+    {
+        if (method_exists($this, 'expectExceptionMessageMatches')) {
+            // PHPUnit 8.4+.
+            $this->expectExceptionMessageMatches($msgRegex);
+            return;
+        }
+
+        // PHPUnit < 8.4.
+        $this->expectExceptionMessageRegExp($msgRegex);
     }
 }

--- a/tests/cases/unit/Expectation/Exception/ExpectationArgsRequiredTest.php
+++ b/tests/cases/unit/Expectation/Exception/ExpectationArgsRequiredTest.php
@@ -29,8 +29,14 @@ class ExpectationArgsRequiredTest extends UnitTestCase
             new ExpectationTarget($type, 'foo')
         )->getMessage();
 
-        static::assertContains($message_part, $message);
+        if ( method_exists( static::class, 'assertStringContainsString' ) ) {
+            // PHPUnit 7.5+.
+            static::assertStringContainsString($message_part, $message);
+            return;
+        }
 
+        // PHPUnit < 7.5.
+        static::assertContains($message_part, $message);
     }
 
     public function expectationTargets()

--- a/tests/src/FunctionalTestCase.php
+++ b/tests/src/FunctionalTestCase.php
@@ -20,13 +20,19 @@ use PHPUnit\Framework\TestCase;
  */
 class FunctionalTestCase extends TestCase
 {
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpFixtures()
     {
         parent::setUp();
         Monkey\setUp();
     }
 
-    protected function tearDown()
+    /**
+     * @after
+     */
+    protected function tearDownFixtures()
     {
         Monkey\tearDown();
         parent::tearDown();

--- a/tests/src/UnitTestCase.php
+++ b/tests/src/UnitTestCase.php
@@ -22,7 +22,10 @@ class UnitTestCase extends TestCase
 {
     private $expect_mockery_exception = null;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpFixtures()
     {
         $this->expect_mockery_exception = null;
         $libPath = explode('/tests/src/', str_replace('\\', '/', __FILE__))[0];
@@ -31,7 +34,10 @@ class UnitTestCase extends TestCase
         require_once "{$libPath}/inc/wp-hook-functions.php";
     }
 
-    protected function tearDown()
+    /**
+     * @after
+     */
+    protected function tearDownFixtures()
     {
         if ( ! $this->expect_mockery_exception) {
             Monkey\tearDown();


### PR DESCRIPTION
## Summary

Made the most minimal changes to allow the tests to run on PHPUnit 8 and 9.

PHPUnit 9.3 is the first version which is officially compatible with the upcoming PHP 8 release, so now the tests can be run on PHP 8 to confirm that BrainMonkey is compatible with PHP 8 (at this time).

Having confirmed this, allows for packages which use the BrainMonkey package to test their code, to be confident to start testing their own code on PHP 8.


## Commit details

### Unit tests: add support for PHPUnit 8.x

In PHPUnit 8.x, the `setUpBeforeClass()`, `tearDownAfterClass()`, `setUp()` and `tearDown()` methods have received type declarations,with a return type `void`, making it neigh impossible to implement this in a cross-version manner as the `void` return type is not available until PHP 7.1.

However, PHPUnit also supports `@beforeClass`, `@afterClass`, `@before` and `@after` annotations to run arbitrary methods for setting things up/tearing things down. Those annotations have been around forever and are support all the way back to PHPUnit 4.x.

So instead of doing convoluted things with extending different classes for different PHPUnit versions or creating classes on the fly for this, by renaming the fixture related methods and using the PHPUnit annotations, the unit test suite becomes compatible with PHPUnit 4.x - 8.x without much effort.

### Tests: add minimal `assertStringContainsString()` compatibility wrapper to one test

To make the tests PHPUnit cross-version compatible, not that much is needed in terms of compatibility polyfills.

The PHPUnit `assertContains()` method could originally be used to check whether an array contained a certain needle or whether a string contained a substring.
This second use has been deprecated in PHPUnit 8 and removed in PHPUnit 9 in favour of dedicated string related assertions which were introduced in PHPUnit 7.5.

As that assertion is only used in one specific test, adding a simple  if/else wrapper which toggles between the "old" method name and the "new" method name fixed cross-version compatibility for this.

### Tests: add minimal `expectExceptionMessageMatches()` compatibility wrapper to one test file

To make the tests PHPUnit cross-version compatible, not that much is needed in terms of compatibility polyfills.

The `expectExceptionMessageRegExp()` method has been removed in favour of the `expectExceptionMessageMatches()` method in PHPUnit 9.

As that assertion is only used in one test file, adding a wrapper method which toggles between the "old" method name and the "new" method name fixed cross-version compatibility for this.

### Tests: add minimal `expectError()` compatibility wrapper to one test file

To make the tests PHPUnit cross-version compatible, not that much is needed in terms of compatibility polyfills.

PHPUnit 8.4 introduced a new API to test PHP native errors/warning/notices and use of the `expectException()` method for testing the PHP native notices is deprecated since PHPUnit 9.0 and support will be removed in PHPUnit 10.

As that type of exception testing is only used in one test file, adding a wrapper method which toggles between the "old" method name and the "new" method name fixed cross-version compatibility for this.

### Composer: allow installation of PHPUnit 8 and 9

Now the tests have been made cross-version compatible with PHPUnit 8 and 9, allow installation of those versions by widening the version restraints in the `composer.json` file.

PHPUnit 8 introduces a form of caching to PHPUnit, so adding this cache file to the `.gitignore` file.

### Travis: run the tests against PHP 8/nightly

Now the tests are fully compatible with PHPUnit 9, the test suite can be run on PHP 8.

Includes changing `7.4snapshot` to `7.4` as that version was released and has been available as an image on Travis for a good 10 months now.

