### PR TITLE
`has_filter` and `has_action` should returns the priority

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -225,9 +225,14 @@ namespace Brain\Monkey\Actions {
      */
     function has($action, $callback = null)
     {
-        return Container::instance()
-                        ->hookStorage()
-                        ->isHookAdded(Hook\HookStorage::ACTIONS, $action, $callback);
+        $type = Hook\HookStorage::ACTIONS;
+        $hookStorage = Container::instance()->hookStorage();
+
+        if ($callback === null) {
+            return $hookStorage->isHookAdded($type, $action);
+        }
+
+        return $hookStorage->hookPriority($type, $action, $callback);
     }
 
     /**
@@ -325,9 +330,14 @@ namespace Brain\Monkey\Filters {
      */
     function has($filter, $callback = null)
     {
-        return Container::instance()
-                        ->hookStorage()
-                        ->isHookAdded(Hook\HookStorage::FILTERS, $filter, $callback);
+        $type = Hook\HookStorage::FILTERS;
+        $hookStorage = Container::instance()->hookStorage();
+
+        if ($callback === null) {
+            return $hookStorage->isHookAdded($type, $filter);
+        }
+
+        return $hookStorage->hookPriority($type, $filter, $callback);
     }
 
     /**

--- a/src/Hook/HookStorage.php
+++ b/src/Hook/HookStorage.php
@@ -132,10 +132,37 @@ final class HookStorage
     }
 
     /**
+     * @param $type
+     * @param $hook
+     * @param $function
+     * @return bool|int
+     */
+    public function hookPriority($type, $hook, $function)
+    {
+        if (!isset($this->storage[self::ADDED][$type][$hook])) {
+            return false;
+        }
+
+        $all = $this->storage[self::ADDED][$type][$hook];
+        $callbackStringForm = \is_string($function) ? new CallbackStringForm($function) : $function;
+
+        /**
+         * @var CallbackStringForm $callback
+         */
+        foreach ($all as $key => list($callback, $priority)) {
+            if ($callback->equals($callbackStringForm)) {
+                return $priority;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param string $key
      * @param string $type
      * @param string $hook
-     * @param array  $args
+     * @param array $args
      * @return static
      */
     private function pushToStorage($key, $type, $hook, array $args)

--- a/tests/cases/unit/Api/AddFiltersTest.php
+++ b/tests/cases/unit/Api/AddFiltersTest.php
@@ -37,13 +37,13 @@ class AddFiltersTest extends UnitTestCase
         });
         add_filter('the_title', [$this, __FUNCTION__], 20);
 
-        static::assertTrue(has_filter('the_title', 'strtolower'));
-        static::assertTrue(has_filter('the_title', 'function(array $title)'));
-        static::assertTrue(has_filter('the_title', __CLASS__.'->'.__FUNCTION__.'()', 20));
+        static::assertEquals(30, has_filter('the_title', 'strtolower'));
+        static::assertEquals(10, has_filter('the_title', 'function(array $title)'));
+        static::assertEquals(20, has_filter('the_title', __CLASS__.'->'.__FUNCTION__.'()'));
 
-        static::assertFalse(has_filter('the_content', 'strtolower', 30, 1));
+        static::assertFalse(has_filter('the_content', 'strtolower'));
         static::assertFalse(has_filter('foo', 'function()'));
-        static::assertFalse(has_filter('bar', __CLASS__.'->'.__FUNCTION__.'()', 20));
+        static::assertFalse(has_filter('bar', __CLASS__.'->'.__FUNCTION__.'()'));
     }
 
     public function testHasWithoutCallback()
@@ -104,7 +104,7 @@ class AddFiltersTest extends UnitTestCase
 
         add_filter('the_title', '__return_empty_string', 20);
 
-        static::assertTrue(has_filter('the_title', '__return_empty_string'));
+        static::assertEquals(20, has_filter('the_title', '__return_empty_string'));
 
         remove_filter('the_title', '__return_empty_string', 20);
 


### PR DESCRIPTION
Accordingly to WordPress the aforementioned functions has to
return the priority value when the callback function is given.

If the PR get merged it will introduce a new method in `HookStorage` named `hookPriority` which allow to retrieve the priority of an hook by the given `type`, `hookName` and `callback`.

The `has_filter` and `has_hook` will make use of the method only if the `callback` parameter has been given, otherwise will continue to call `isHookAdded`.

The Method `HookStorage::hookPriority` explicitly does not cover the case where a different value other than `string` or `CallbackStringForm` has been passed, so that the developer is notified about the violation but it will try to convert a string into a `CallbackStringForm` instance for convenience.

The method returns the priority or false in case priority cannot be retrieved because zero and negative values are also possibile priorities in WordPress. 

Not sure if would be convenient to just return `null` since we're doing a search and we found nothing.
More over, do make sense to introduce a sort of cache to prevent to loop again and again looking for the priority when exactly the same parameters are given? 

The introduction of a cache would probably means touching other parts of the code since it has to be completely cleaned when something change in the storage.

#79 