### PR TITLE
WP: stub the `esc_xml()` function

### DIFF
--- a/docs/functions-testing-tools/function-stubs.md
+++ b/docs/functions-testing-tools/function-stubs.md
@@ -105,6 +105,7 @@ When called, it will create a stub for each of the following functions:
 * `esc_textarea()`
 * `esc_url()`
 * `esc_url_raw()`
+* `esc_xml()` \(since 2.6\)
 
 By calling `Functions\stubEscapeFunctions()`, for _all_ of the functions listed above a stub will be created that will do some very basic escaping on the received first argument before returning it.
 

--- a/inc/api.php
+++ b/inc/api.php
@@ -172,6 +172,7 @@ namespace Brain\Monkey\Functions {
                 'esc_textarea' => [EscapeHelper::class, 'esc'],
                 'esc_url'      => [EscapeHelper::class, 'escUrl'],
                 'esc_url_raw'  => [EscapeHelper::class, 'escUrlRaw'],
+                'esc_xml'      => [EscapeHelper::class, 'escXml'],
             ]
         );
     }

--- a/tests/cases/unit/Api/FunctionsTest.php
+++ b/tests/cases/unit/Api/FunctionsTest.php
@@ -373,4 +373,60 @@ class FunctionsTest extends UnitTestCase
         static::assertSame("hello, \\'world\\'", esc_sql("hello, 'world'"));
         static::assertSame('<b>hello world</b>', esc_sql('<b>hello world</b>'));
     }
+
+    /**
+     * @dataProvider dataStubsEscapeXml
+     */
+    public function testStubsEscapeXml($input, $expected)
+    {
+        Functions\stubEscapeFunctions();
+
+        static::assertSame($expected, esc_xml($input));
+    }
+
+    public function dataStubsEscapeXml()
+    {
+        return [
+            [
+                'The quick brown fox.',
+                'The quick brown fox.',
+            ],
+            [
+                'http://localhost/trunk/wp-login.php?action=logout&_wpnonce=cd57d75985',
+                'http://localhost/trunk/wp-login.php?action=logout&amp;_wpnonce=cd57d75985',
+            ],
+            [
+                '&#038; &#x00A3; &#x22; &amp;',
+                '&amp; £ " &amp;', // Note: this is different from WP native!
+            ],
+            [
+                'this &amp; is a &hellip; followed by &rsaquo; and more and a &nonexistent; entity',
+                'this &amp; is a … followed by › and more and a &amp;nonexistent; entity',
+            ],
+            [
+                "This is\na<![CDATA[test of\nthe <emergency>]]>\nbroadcast system",
+                "This is\na<![CDATA[test of\nthe <emergency>]]>\nbroadcast system",
+            ],
+            [
+                'This is &hellip; a <![CDATA[test of the <emergency>]]> broadcast <system />',
+                'This is … a <![CDATA[test of the <emergency>]]> broadcast &lt;system /&gt;',
+            ],
+            [
+                '<![CDATA[test of the <emergency>]]> This is &hellip; a broadcast <system />',
+                '<![CDATA[test of the <emergency>]]> This is … a broadcast &lt;system /&gt;',
+            ],
+            [
+                'This is &hellip; a broadcast <system /><![CDATA[test of the <emergency>]]>',
+                'This is … a broadcast &lt;system /&gt;<![CDATA[test of the <emergency>]]>',
+            ],
+            [
+                'This is &hellip; a <![CDATA[test of the <emergency>]]> &broadcast; <![CDATA[<system />]]>',
+                'This is … a <![CDATA[test of the <emergency>]]> &amp;broadcast; <![CDATA[<system />]]>',
+            ],
+            [
+                '<![CDATA[<&]]>]]>',
+                '<![CDATA[<&]]>]]&gt;',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
WP 5.5 introduced a new escaping function `esc_xml()`.

This largely stubs that function, except for some real edge cases.

Tests based on the tests used in WP Core.

Ref: https://developer.wordpress.org/reference/functions/esc_xml/