### PR TITLE
Docs: add x-links for WP stubs

### DIFF
--- a/docs/wordpress-specific-tools/wordpress-tools.md
+++ b/docs/wordpress-specific-tools/wordpress-tools.md
@@ -44,6 +44,15 @@ Following functions are defined by Brain Monkey when it is loaded for tests:
 * `absint()` \(since 2.3\)
 * `is_wp_error()` \(since 2.3\)
 
+**Translation function:**
+
+Since Brain Monkey 2.3, stubs for the standard WordPress translations functions are available via `Functions\stubEscapeFunctions()`.
+See: [Pre-defined stubs for translation functions](https://giuseppe-mazzapica.gitbook.io/brain-monkey/functions-testing-tools/function-stubs#pre-defined-stubs-for-translation-functions)
+
+**Escaping functions:**
+Since Brain Monkey 2.3, stubs for the standard WordPress escaping functions are available via `Functions\stubTranslationFunctions()`.
+See: [Pre-defined stubs for escaping functions](https://giuseppe-mazzapica.gitbook.io/brain-monkey/functions-testing-tools/function-stubs#pre-defined-stubs-for-escaping-functions)
+
 If your code uses any of these functions, and very likely it does, you don't need to define \(or mock\) them to avoid fatal errors during tests.
 
 Note that the returning value of those functions \(_most of the times_\) will work out of the box as you might expect.


### PR DESCRIPTION
The WordPress specific `stubEscapeFunctions()` and `stubTranslationFunctions()` tools are mentioned in the "Bulk patching with stubs()" section, but not in the WordPress specific tools section.

This attempts to make these (very useful) functions more discoverable by adding links to the "Bulk patching with stubs()" section from the "WordPress testing tools" section.