### PR TITLE
WP: stub the `_n()` and `_nx()` functions

### DIFF
--- a/docs/functions-testing-tools/function-stubs.md
+++ b/docs/functions-testing-tools/function-stubs.md
@@ -120,9 +120,11 @@ Since version 2.3, this has became much easier thanks to the introduction of a n
 
 When called, it will create a stub for _all_ the following functions:
 
-* `__()`        
-* `_x()`       
-* `translate()` 
+* `__()`
+* `_x()`
+* `_n()` \(since 2.6\)
+* `_nx()` \(since 2.6\)
+* `translate()`
 * `esc_html__()`
 * `esc_html_x()`
 * `esc_attr__()` 

--- a/inc/api.php
+++ b/inc/api.php
@@ -143,6 +143,12 @@ namespace Brain\Monkey\Functions {
                 '__',
                 '_x',
                 'translate',
+                '_n'         => static function($single, $plural, $number) {
+                    return ($number === 1) ? $single : $plural;
+                },
+                '_nx'        => static function($single, $plural, $number) {
+                    return ($number === 1) ? $single : $plural;
+                },
                 'esc_html__' => [EscapeHelper::class, 'esc'],
                 'esc_html_x' => [EscapeHelper::class, 'esc'],
                 'esc_attr__' => [EscapeHelper::class, 'esc'],

--- a/tests/cases/unit/Api/FunctionsTest.php
+++ b/tests/cases/unit/Api/FunctionsTest.php
@@ -321,10 +321,12 @@ class FunctionsTest extends UnitTestCase
         Functions\stubTranslationFunctions();
 
         static::assertSame('Foo', __('Foo', 'my-txt-domain'));
-        static::assertSame('Foo!', _x('Foo!', 'context',  'my-txt-domain'));
+        static::assertSame('Foo!', _x('Foo!', 'context', 'my-txt-domain'));
+        static::assertSame('one', _n('one', 'more', 1, 'my-txt-domain'));
+        static::assertSame('more', _nx('one', 'more', 2, 'context', 'my-txt-domain'));
         static::assertSame('Bar!', esc_html__('Bar!', 'my-txt-domain'));
         static::assertSame('Baz!', esc_attr__('Baz!', 'my-txt-domain'));
-        static::assertSame('Foo bar', esc_attr_x('Foo bar', 'context',  'my-txt-domain'));
+        static::assertSame('Foo bar', esc_attr_x('Foo bar', 'context', 'my-txt-domain'));
     }
 
     public function testStubsTranslationsEcho()


### PR DESCRIPTION
Along the same lines as the other translation functions stubs, this returns the original text unchanged.

Refs:
* https://developer.wordpress.org/reference/functions/_n/
* https://developer.wordpress.org/reference/functions/_nx/