### PR TITLE
WP helper functions: stub user_trailingslashit() and wp_json_encode()

### DIFF
--- a/docs/wordpress-specific-tools/wordpress-tools.md
+++ b/docs/wordpress-specific-tools/wordpress-tools.md
@@ -41,6 +41,7 @@ Following functions are defined by Brain Monkey when it is loaded for tests:
 * `__return_empty_string()`
 * `trailingslashit()`
 * `untrailingslashit()`
+* `user_trailingslashit()` \(since 2.6\)
 * `absint()` \(since 2.3\)
 * `is_wp_error()` \(since 2.3\)
 

--- a/docs/wordpress-specific-tools/wordpress-tools.md
+++ b/docs/wordpress-specific-tools/wordpress-tools.md
@@ -43,6 +43,7 @@ Following functions are defined by Brain Monkey when it is loaded for tests:
 * `untrailingslashit()`
 * `user_trailingslashit()` \(since 2.6\)
 * `absint()` \(since 2.3\)
+* `wp_json_encode()` \(since 2.6\)
 * `is_wp_error()` \(since 2.3\)
 
 If your code uses any of these functions, and very likely it does, you don't need to define \(or mock\) them to avoid fatal errors during tests.

--- a/inc/wp-helper-functions.php
+++ b/inc/wp-helper-functions.php
@@ -73,6 +73,13 @@ if ( ! function_exists('trailingslashit')) {
     }
 }
 
+if ( ! function_exists('user_trailingslashit')) {
+    function user_trailingslashit($string)
+    {
+        return trailingslashit($string);
+    }
+}
+
 if ( ! function_exists('absint')) {
     function absint($number)
     {

--- a/inc/wp-helper-functions.php
+++ b/inc/wp-helper-functions.php
@@ -87,6 +87,13 @@ if ( ! function_exists('absint')) {
     }
 }
 
+if ( ! function_exists('wp_json_encode')) {
+    function wp_json_encode($data, $options = 0, $depth = 512)
+    {
+        return json_encode($data, $options, $depth);
+    }
+}
+
 if ( ! function_exists('is_wp_error')) {
     function is_wp_error($thing)
     {


### PR DESCRIPTION
### WP helper functions: stub user_trailingslashit()

Simply `trailingslashit` without further ado.

Includes adding the new stub to the documentation.

Excludes tests as I couldn't find tests for the other functions in this file, so it is unclear to me where to add them.

Ref: https://developer.wordpress.org/reference/functions/user_trailingslashit/

### WP helper functions: stub wp_json_encode()

Simply `json_encode()` without further ado.

Includes adding the new stub to the documentation.

Excludes tests as I couldn't find tests for the other functions in this file, so it is unclear to me where to add them.

Ref: https://developer.wordpress.org/reference/functions/wp_json_encode/

---

Related to #81