### PR TITLE
Docs: add more functions missing from lists

### DIFF
--- a/docs/functions-testing-tools/function-stubs.md
+++ b/docs/functions-testing-tools/function-stubs.md
@@ -120,9 +120,11 @@ Since version 2.3, this has became much easier thanks to the introduction of a n
 
 When called, it will create a stub for _all_ the following functions:
 
-* `__()`        
-* `_x()`       
-* `translate()` 
+* `__()`
+* `_e()`
+* `_ex()`
+* `_x()`
+* `translate()`
 * `esc_html__()`
 * `esc_html_x()`
 * `esc_attr__()` 


### PR DESCRIPTION
Looking at the `Brain\Monkey\Functions\stubTranslationFunctions()` function, the `_e()` and `_ex()` functions are actually also stubbed.

https://github.com/Brain-WP/BrainMonkey/blob/dbb41d3e56d7a768c7f44f909f428d1503f82106/inc/api.php#L134-L157