### PR TITLE
GH Actions: start testing against PHP 8.1

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -8,6 +8,13 @@ jobs:
             fail-fast: true
             matrix:
                 php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+                experimental: [false]
+
+                include:
+                    # Experimental builds. These are allowed to fail.
+                    - php-versions: '8.1'
+                      experimental: true
+        continue-on-error: ${{ matrix.experimental }}
         steps:
             - uses: actions/checkout@v2
 
@@ -19,8 +26,13 @@ jobs:
             - name: Check syntax error in sources
               run: find ./src/ ./tests/ -type f -name '*.php' -print0 | xargs -0 -L 1 -P 4 -- php -l
 
-            - name: Install dependencies
+            - name: Install dependencies - normal
+              if: ${{ matrix.php-versions != '8.1' }}
               run: composer install -q -n -a --no-progress --prefer-dist
+
+            - name: Install dependencies - ignore-platform-reqs
+              if: ${{ matrix.php-versions == '8.1' }}
+              run: composer install -q -n -a --no-progress --prefer-dist --ignore-platform-reqs
 
             - name: Check cross-version PHP compatibility
               if: ${{ matrix.php-versions == '7.4' }} # results is same across versions, do it once

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -22,6 +22,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                 php-version: ${{ matrix.php-versions }}
+                ini-values: error_reporting=E_ALL, display_errors=On
 
             - name: Check syntax error in sources
               run: find ./src/ ./tests/ -type f -name '*.php' -print0 | xargs -0 -L 1 -P 4 -- php -l


### PR DESCRIPTION
The first alpha of PHP 8.1 has been released, so now seems like a good time to start running the tests against PHP 8.1.

For now, I've configured it to allow builds against PHP 8.1 to fail, while PHP 8.1 is still unstable.

Also: PHPUnit doesn't officially support PHP 8.1 yet, so to install PHPUnit 9.x on PHP 8.1, we need to use `--ignore-platform-reqs`, as otherwise PHPUnit 4.8 would be installed (last PHPUnit version without strict PHP version constraints).

---

**Edit**: I've added a second commit to this PR.

### GH Actions: set error reporting to E_ALL

Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.
