### PR TITLE
Make the `ClosureParamStringForm` class compatible with PHP 5.6

### DIFF
--- a/tests/cases/unit/Name/ClosureParamStringFormTest.php
+++ b/tests/cases/unit/Name/ClosureParamStringFormTest.php
@@ -55,14 +55,8 @@ class ClosureParamStringFormTest extends UnitTestCase
         static::assertFalse(ClosureParamStringForm::fromString(' $foo ')->isVariadic());
     }
 
-    public function testFromStringToString7()
+    public function testFromStringToString()
     {
-        if (PHP_MAJOR_VERSION < 7) {
-            $this->markTestSkipped('Skipping PHP 7 test.');
-
-            return;
-        }
-
         $param_a = ClosureParamStringForm::fromString('Foo $foo');
         $param_b = ClosureParamStringForm::fromString('...$foo');
         $param_c = ClosureParamStringForm::fromString(' ... $foo');
@@ -79,33 +73,6 @@ class ClosureParamStringFormTest extends UnitTestCase
         static::assertSame('Foo ...$foo', (string)$param_e);
         static::assertSame('Foo\Bar ...$bar', (string)$param_f);
         static::assertSame('Foo\Bar ...$bar', (string)$param_g);
-        static::assertSame('$foo', (string)$param_h);
-    }
-
-    public function testFromStringToString5()
-    {
-        if (PHP_MAJOR_VERSION >= 7) {
-            $this->markTestSkipped('Skipping PHP 5.6 test.');
-
-            return;
-        }
-
-        $param_a = ClosureParamStringForm::fromString('Foo $foo');
-        $param_b = ClosureParamStringForm::fromString('...$foo');
-        $param_c = ClosureParamStringForm::fromString(' ... $foo');
-        $param_d = ClosureParamStringForm::fromString('Foo ...$foo');
-        $param_e = ClosureParamStringForm::fromString(' Foo ... $foo ');
-        $param_f = ClosureParamStringForm::fromString('Foo\Bar ...$bar');
-        $param_g = ClosureParamStringForm::fromString(' Foo\Bar ... $bar ');
-        $param_h = ClosureParamStringForm::fromString(' $foo ');
-
-        static::assertSame('$foo', (string)$param_a);
-        static::assertSame('...$foo', (string)$param_b);
-        static::assertSame('...$foo', (string)$param_c);
-        static::assertSame('...$foo', (string)$param_d);
-        static::assertSame('...$foo', (string)$param_e);
-        static::assertSame('...$bar', (string)$param_f);
-        static::assertSame('...$bar', (string)$param_g);
         static::assertSame('$foo', (string)$param_h);
     }
 
@@ -159,20 +126,36 @@ class ClosureParamStringFormTest extends UnitTestCase
             return;
         }
 
-        $param = \Mockery::mock(\ReflectionParameter::class);
+        $param_a = \Mockery::mock(\ReflectionParameter::class);
         /** @noinspection PhpMethodParametersCountMismatchInspection */
-        $param->shouldReceive('hasType')->never();
+        $param_a->shouldReceive('hasType')->never();
         /** @noinspection PhpMethodParametersCountMismatchInspection */
-        $param->shouldReceive('getType')->never();
+        $param_a->shouldReceive('__toString')->andReturn('Parameter #0 [ <optional> array ...$foo ]');
         /** @noinspection PhpMethodParametersCountMismatchInspection */
-        $param->shouldReceive('getName')->andReturn('foo');
+        $param_a->shouldReceive('getName')->andReturn('foo');
         /** @noinspection PhpMethodParametersCountMismatchInspection */
-        $param->shouldReceive('isVariadic')->andReturn(true);
+        $param_a->shouldReceive('isVariadic')->andReturn(true);
 
         /** @noinspection PhpParamsInspection */
         static::assertSame(
-            '...$foo',
-            (string)ClosureParamStringForm::fromReflectionParameter($param)
+            'array ...$foo',
+            (string)ClosureParamStringForm::fromReflectionParameter($param_a)
+        );
+
+        $param_b = \Mockery::mock(\ReflectionParameter::class);
+        /** @noinspection PhpMethodParametersCountMismatchInspection */
+        $param_b->shouldReceive('hasType')->andReturn(true);
+        /** @noinspection PhpMethodParametersCountMismatchInspection */
+        $param_b->shouldReceive('__toString')->andReturn('Parameter #0 [ <optional> Foo\\Bar ...$bar ]');
+        /** @noinspection PhpMethodParametersCountMismatchInspection */
+        $param_b->shouldReceive('getName')->andReturn('bar');
+        /** @noinspection PhpMethodParametersCountMismatchInspection */
+        $param_b->shouldReceive('isVariadic')->andReturn(true);
+
+        /** @noinspection PhpParamsInspection */
+        static::assertSame(
+            'Foo\\Bar ...$bar',
+            (string)ClosureParamStringForm::fromReflectionParameter($param_b)
         );
     }
 }

--- a/tests/cases/unit/Name/ClosureStringFormTest.php
+++ b/tests/cases/unit/Name/ClosureStringFormTest.php
@@ -55,14 +55,8 @@ class ClosureStringFormTest extends UnitTestCase
         static::assertSame('function ($foo, $bar)', (string)$string_form);
     }
 
-    public function testArgsTypeHints7()
+    public function testArgsTypeHints()
     {
-        if (PHP_MAJOR_VERSION < 7) {
-            $this->markTestSkipped('Skipping PHP 7 test.');
-
-            return;
-        }
-
         $callback = function (\ArrayObject $foo, array $bar, \stdClass... $classes) {
 
         };
@@ -75,34 +69,8 @@ class ClosureStringFormTest extends UnitTestCase
         );
     }
 
-    public function testArgsTypeHints5()
+    public function testStaticArgsTypeHints()
     {
-        if (PHP_MAJOR_VERSION >= 7) {
-            $this->markTestSkipped('Skipping PHP 5.6 test.');
-
-            return;
-        }
-
-        $callback = function (\ArrayObject $foo, array $bar, \stdClass... $classes) {
-
-        };
-
-        $string_form = new ClosureStringForm($callback);
-
-        static::assertSame(
-            'function ($foo, $bar, ...$classes)',
-            (string)$string_form
-        );
-    }
-
-    public function testStaticArgsTypeHints7()
-    {
-        if (PHP_MAJOR_VERSION < 7) {
-            $this->markTestSkipped('Skipping PHP 7 test.');
-
-            return;
-        }
-
         $callback = static function (\ArrayObject $foo, array $bar, \stdClass... $classes) {
 
         };
@@ -111,26 +79,6 @@ class ClosureStringFormTest extends UnitTestCase
 
         static::assertSame(
             'static function (ArrayObject $foo, array $bar, stdClass ...$classes)',
-            (string)$string_form
-        );
-    }
-
-    public function testStaticArgsTypeHints5()
-    {
-        if (PHP_MAJOR_VERSION >= 7) {
-            $this->markTestSkipped('Skipping PHP 5.6 test.');
-
-            return;
-        }
-
-        $callback = static function (\ArrayObject $foo, array $bar, \stdClass... $classes) {
-
-        };
-
-        $string_form = new ClosureStringForm($callback);
-
-        static::assertSame(
-            'static function ($foo, $bar, ...$classes)',
             (string)$string_form
         );
     }
@@ -156,34 +104,12 @@ class ClosureStringFormTest extends UnitTestCase
         static::assertSame('static function ()', ClosureStringForm::normalizeString($closure_d));
     }
 
-    public function testParseStringWithArgs7()
+    public function testParseStringWithArgs()
     {
-        if (PHP_MAJOR_VERSION < 7) {
-            $this->markTestSkipped('Skipping PHP 7 test.');
-
-            return;
-        }
-
         $closure = ' static function( \ArrayObject $foo,array $bar,stdClass ...$classes ) ';
 
         static::assertSame(
             'static function (ArrayObject $foo, array $bar, stdClass ...$classes)',
-            ClosureStringForm::normalizeString($closure)
-        );
-    }
-
-    public function testParseStringWithArgs5()
-    {
-        if (PHP_MAJOR_VERSION >= 7) {
-            $this->markTestSkipped('Skipping PHP 5.6 test.');
-
-            return;
-        }
-
-        $closure = ' static function( \ArrayObject $foo,array $bar,stdClass ...$classes ) ';
-
-        static::assertSame(
-            'static function ($foo, $bar, ...$classes)',
             ClosureStringForm::normalizeString($closure)
         );
     }


### PR DESCRIPTION
This commit makes the `ClosureParamStringForm` class compatible with PHP 5.6, both for the `fromString()`, as well as the `fromReflectionParameter()` method.

### Regarding the `fromReflectionParameter()` method:

In PHP 5.6, to retrieve the type, typically a pattern along the following lines would be used:
```php
try {
    $hasType = $reflParameter->getClass();
} catch ( ReflectionException $e ) {
    // Class with a type declaration for a non-existent class.
}

$typeName = $hasType->name;
```

The downside of the above is that the `ReflectionParameter::getClass()` method triggers an autoload of the class (for class-based type declarations).
See: https://www.php.net/manual/en/reflectionparameter.getclass.php#108620

In a test situation, this autoload should not be triggered by the tests, so instead of this pattern, the `ReflectionParameter::__toString()` method is used to retrieve a string representation of the parameter declaration, which is subsequently parsed using a regular expression.

The tests which were originally added in #95 for PHP 5.6, have been brought back and adjusted for this manner of handling the parameter.

### Regarding the `fromString()` method:

This method was already perfectly capable of handling the parameter parsing in PHP 5.6, but the `(PHP_MAJOR_VERSION < 7) and $type_name = '';` condition in the `ClosureParamStringForm::__construct()` method prevented it from storing the retrieved `$type_name`.

Now the `fromReflectionParameter()` method has been made compatible with PHP 5.6, that line in the `ClosureParamStringForm::__construct()` method can be removed and the separate set of tests for PHP 5.6 for the `fromString()` method can be removed.

## Regarding the `ClosureStringFormTest` class

As both entry methods to the `ClosureParamStringForm` class are now compatible with PHP 5.6, the segregated tests for PHP 5.6 vs PHP 7+ in the `ClosureStringFormTest` class can be consolidated again.

Fixes #94

**_Note: obviously, if people would use scalar type declarations, this will break, but in that case, I wouldn't expect them to even attempt to run their tests for those methods on PHP 5.6 as scalar type declarations are only available in PHP >= 7.0._**
To me, that is a case of end-user's own responsibility and not something this library should be concerned about.