### PR TITLE
GH Actions: run the tests on PHP >= 7.3

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -39,12 +39,11 @@ jobs:
               if: ${{ matrix.php-versions == '7.4' }} # results is same across versions, do it once
               run: composer phpcompat
 
-            - name: Run unit tests (>= 7.3)
+            - name: Migrate test configuration (>= 7.3)
               if: ${{ matrix.php-versions >= 7.3 }}
-              run: ./vendor/bin/phpunit --coverage-clover=coverage.xml --migrate-configuration
+              run: ./vendor/bin/phpunit --migrate-configuration
 
-            - name: Run unit tests (< 7.3)
-              if: ${{ matrix.php-versions < 7.3 }}
+            - name: Run unit tests
               run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
             - name: Update codecov.io


### PR DESCRIPTION
I was looking through the action output and was a bit confused by the test runs on PHP >= 7.3 not showing any run information.

Turns out, the tests haven't been running on PHP > 7.3 since October last year, as the `--migrate-configuration` CLI argument is supposed to be used as a stand-alone command and does not trigger a test run after the migration has finished....

Fixed now.


Note: this now exposes quite a lot of problems on PHP 8.1, some in Patchwork, some in Mockery. I'm especially concerned about the issues in Patchwork as the last commit to that repo was in 2019.