### PR TITLE
Composer: update the minimum version requirement for Patchwork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=5.6.0",
         "mockery/mockery": ">=0.9 <2",
-        "antecedent/patchwork": "^2.0"
+        "antecedent/patchwork": "^2.1.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0 || ^8.0 || ^9.0",


### PR DESCRIPTION
Patchwork 2.1.13 has just been released and includes improved PHP 8.0 support and fixes for PHP 8.1 support.

I'd recommend making this the new minimum supported version for Patchwork.

Ref: https://github.com/antecedent/patchwork/releases