### PR TITLE
PHP 8.1: fix a test

### DIFF
--- a/tests/cases/functional/FunctionsTest.php
+++ b/tests/cases/functional/FunctionsTest.php
@@ -59,7 +59,7 @@ class FunctionsTest extends FunctionalTestCase
         Monkey\Functions\when('is_wp_error')->alias('ctype_alpha');
 
         static::assertTrue(is_wp_error('xyz'));
-        static::assertFalse(is_wp_error(123));
+        static::assertFalse(is_wp_error('123'));
     }
 
     public function testReDefinePredefinedStubsWithExpect()


### PR DESCRIPTION
In this particular test the `is_wp_error()` function is being aliased to the PHP native `ctype_alpha()` function, but that function expects to be passed a string, while the second test was passing an integer.

By changing the type of the value passed, but keeping the value the same, this PHP 8.1 deprecation notice is avoided.

Fixes the following test failure as per https://github.com/Brain-WP/BrainMonkey/issues/103#issuecomment-927148428
```
Brain\Monkey\Tests\Functional\FunctionsTest::testReDefinePredefinedStubsWithWhen
ctype_alpha(): Argument of type int will be interpreted as string in the future

/home/runner/work/BrainMonkey/BrainMonkey/vendor/antecedent/patchwork/src/CallRerouting.php:285
/home/runner/work/BrainMonkey/BrainMonkey/vendor/antecedent/patchwork/src/CallRerouting.php:317
/home/runner/work/BrainMonkey/BrainMonkey/vendor/antecedent/patchwork/src/Stack.php:27
/home/runner/work/BrainMonkey/BrainMonkey/vendor/antecedent/patchwork/src/CallRerouting.php:309
/home/runner/work/BrainMonkey/BrainMonkey/inc/wp-helper-functions.php:99
/home/runner/work/BrainMonkey/BrainMonkey/tests/cases/functional/FunctionsTest.php:62
```

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_1#ctype_function_family_accepts_int_parameters
* https://www.php.net/manual/en/function.ctype-alpha.php