### PR TITLE
Composer: minor tweak to script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     },
     "scripts" : {
         "phpcompat": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -p . --standard=PHPCompatibility --ignore=*/vendor/* --extensions=php --basepath=./ --runtime-set testVersion 5.6-"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -ps . --standard=PHPCompatibility --ignore=*/vendor/* --extensions=php --basepath=./ --runtime-set testVersion 5.6-"
         ]
     }
 }


### PR DESCRIPTION
Show the error codes if/when a PHPCompatibility error is thrown to make it easier to add an ignore comment if/when needed.