### PR TITLE
GH Actions: don't allow failures on PHP 8.1

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -7,14 +7,10 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
-                experimental: [false]
+                php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
-                include:
-                    # Experimental builds. These are allowed to fail.
-                    - php-versions: '8.1'
-                      experimental: true
-        continue-on-error: ${{ matrix.experimental }}
+        continue-on-error: ${{ matrix.php-versions == '8.2' }}
+
         steps:
             - uses: actions/checkout@v2
 
@@ -22,17 +18,17 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                 php-version: ${{ matrix.php-versions }}
-                ini-values: error_reporting=E_ALL, display_errors=On
+                ini-values: error_reporting=-1, display_errors=On
 
             - name: Check syntax error in sources
               run: find ./src/ ./tests/ -type f -name '*.php' -print0 | xargs -0 -L 1 -P 4 -- php -l
 
             - name: Install dependencies - normal
-              if: ${{ matrix.php-versions != '8.1' }}
+              if: ${{ matrix.php-versions != '8.2' }}
               run: composer install -q -n -a --no-progress --prefer-dist
 
             - name: Install dependencies - ignore-platform-reqs
-              if: ${{ matrix.php-versions == '8.1' }}
+              if: ${{ matrix.php-versions == '8.2' }}
               run: composer install -q -n -a --no-progress --prefer-dist --ignore-platform-reqs
 
             - name: Check cross-version PHP compatibility


### PR DESCRIPTION
As the test failures on PHP 8.1 have now all been fixed, let's safeguard this by no longer allowing the build against PHP 8.1 to fail.

Includes:
* Adding PHP 8.2 for early testing.
    This image is available in `setup-php` since version 2.13.0.
    https://github.com/shivammathur/setup-php/releases
* Updating the "Install dependencies" steps.
    All dependencies have now released versions which proclaim to be compatible with PHP 8.1, so `--ignore-platform-reqs` is no longer needed for PHP 8.1, though it is needed for PHP 8.2.
* MInor matrix/allow to fail simplification.
* Setting the `error_reporting` ini value to `-1`. The `E_ALL` constant did not always show **all** errors across PHP versions, using `-1` will always show **all* errors, independently of the PHP version.