### PR TITLE
Composer: update minimum supported Patchwork version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=5.6.0",
         "mockery/mockery": ">=0.9 <2",
-        "antecedent/patchwork": "^2.1.13"
+        "antecedent/patchwork": "^2.1.17"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0 || ^8.0 || ^9.0",


### PR DESCRIPTION
The last few releases of Patchwork fixed up more PHP syntax issues and further improve PHP 8.0 and 8.1 compatibility.

Ref: https://github.com/antecedent/patchwork/releases