### PR TITLE
Composer: update dev-dependency constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "phpcompatibility/php-compatibility": "^9.3.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || ^0.7"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As this repo is not a PHPCS standard, there is no need to allow for a range of versions for the `dealerdirect/phpcodesniffer-composer-installer` dependency, so best to use the latest version.

https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases