### PR TITLE
Composer: update PHPUnit version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "antecedent/patchwork": "^2.1.17"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0 || >=8.0 <8.5.12 || ^8.5.14 || ^9.0",
         "phpcompatibility/php-compatibility": "^9.3.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || ^0.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "antecedent/patchwork": "^2.1.17"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0 || >=8.0 <8.5.12 || ^8.5.14 || ^9.0",
+        "phpunit/phpunit": "^5.7.26 || ^6.0 || ^7.0 || >=8.0 <8.5.12 || ^8.5.14 || ^9.0",
         "phpcompatibility/php-compatibility": "^9.3.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || ^0.7"
     },


### PR DESCRIPTION
**Note:** while BrainMonkey doesn't have a direct, non-dev dependency on PHPUnit, it will generally be used in combination with PHPUnit. So, while I could have updated the `dev` version constraints to only allow for the latest minors of various PHPUnit versions, it seemed more prudent to allow for a liberal range of versions to allow for discovering potential incompatibilities with PHPUnit versions.


### Composer: update PHPUnit version constraints [1]

While PHPUnit as of version 8.5.12 allows for installation on PHP 8.0, it still contained a [nasty bug](sebastianbergmann/phpunit#4575) which would error out the test run with a Fatal when PHPUnit 8.5.12 would be installed for PHP 8.1.

This bug was fixed in version 8.5.14.

This adjustment of the version constraints means that when `composer install` is run with `--prefer-lowest` on PHP 8.x, PHPUnit 8.5.14 will be installed instead of PHP 8.5.12, while still allowing for all other 8.x versions in all other circumstances.

Ref: https://github.com/sebastianbergmann/phpunit/blob/8.5/ChangeLog-8.5.md

### Composer: update PHPUnit version constraints [2]

PHPUnit 5.x allows for installation on PHP 5.6 and 7.x, however until version 5.7.26, it [used the `each()` function](sebastianbergmann/phpunit#2472), which was deprecated in PHP 7.2, which means that test runs against PHPUnit < 5.7.26 in combination with PHP 7.2 and higher would error out.

This adjustment of the version constraints means that when `composer install` is run with `--prefer-lowest` on PHP 5.6/7.x, PHPUnit 5.7.26 will be installed instead of PHP 5.7.9, preventing this issue.

Ref: https://github.com/sebastianbergmann/phpunit/blob/5.7.27/ChangeLog-5.7.md