### PR TITLE
GH Actions: mixed bag of improvements

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -7,7 +7,12 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+                php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+                dependency-versions: ['lowest', 'highest']
+
+                include:
+                - php-versions: '8.2'
+                  dependency-versions: 'highest'
 
         continue-on-error: ${{ matrix.php-versions == '8.2' }}
 
@@ -23,36 +28,40 @@ jobs:
                 tools: parallel-lint
 
             - name: Check syntax error in sources
+              if: ${{ matrix.dependency-versions == 'highest' }}
               run: parallel-lint ./src/ ./tests/
 
             - name: Install dependencies - normal
               if: ${{ matrix.php-versions != '8.2' }}
               uses: "ramsey/composer-install@v1"
+              with:
+                dependency-versions: ${{ matrix.dependency-versions }}
 
             - name: Install dependencies - ignore-platform-reqs
               if: ${{ matrix.php-versions == '8.2' }}
               uses: "ramsey/composer-install@v1"
               with:
+                dependency-versions: ${{ matrix.dependency-versions }}
                 composer-options: "--ignore-platform-reqs"
 
             - name: Check cross-version PHP compatibility
-              if: ${{ matrix.php-versions == '7.4' }} # results is same across versions, do it once
+              if: ${{ matrix.php-versions == '7.4' && matrix.dependency-versions == 'highest' }} # results is same across versions, do it once
               run: composer phpcompat
 
             - name: Migrate test configuration (>= 7.3)
-              if: ${{ matrix.php-versions >= 7.3 }}
+              if: ${{ matrix.php-versions >= 7.3 && matrix.dependency-versions == 'highest' }}
               run: ./vendor/bin/phpunit --migrate-configuration
 
             - name: Run unit tests (without code coverage)
-              if: ${{ matrix.php-versions != '7.4' }}
+              if: ${{ matrix.php-versions != '7.4' || matrix.dependency-versions != 'highest' }}
               run: ./vendor/bin/phpunit
 
             - name: Run unit tests with code coverage
-              if: ${{ matrix.php-versions == '7.4' }}
+              if: ${{ matrix.php-versions == '7.4' && matrix.dependency-versions == 'highest' }}
               run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
             - name: Update codecov.io
               uses: codecov/codecov-action@v1
-              if: ${{ matrix.php-versions == '7.4' }} # upload coverage once is enough
+              if: ${{ matrix.php-versions == '7.4' && matrix.dependency-versions == 'highest' }} # upload coverage once is enough
               with:
                 file: ./coverage.xml

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -26,11 +26,13 @@ jobs:
 
             - name: Install dependencies - normal
               if: ${{ matrix.php-versions != '8.2' }}
-              run: composer install -q -n -a --no-progress --prefer-dist
+              uses: "ramsey/composer-install@v1"
 
             - name: Install dependencies - ignore-platform-reqs
               if: ${{ matrix.php-versions == '8.2' }}
-              run: composer install -q -n -a --no-progress --prefer-dist --ignore-platform-reqs
+              uses: "ramsey/composer-install@v1"
+              with:
+                composer-options: "--ignore-platform-reqs"
 
             - name: Check cross-version PHP compatibility
               if: ${{ matrix.php-versions == '7.4' }} # results is same across versions, do it once

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -19,6 +19,7 @@ jobs:
               with:
                 php-version: ${{ matrix.php-versions }}
                 ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+                coverage: ${{ ( matrix.php-versions == '7.4' && 'xdebug' ) || 'none' }}
                 tools: parallel-lint
 
             - name: Check syntax error in sources
@@ -42,7 +43,12 @@ jobs:
               if: ${{ matrix.php-versions >= 7.3 }}
               run: ./vendor/bin/phpunit --migrate-configuration
 
-            - name: Run unit tests
+            - name: Run unit tests (without code coverage)
+              if: ${{ matrix.php-versions != '7.4' }}
+              run: ./vendor/bin/phpunit
+
+            - name: Run unit tests with code coverage
+              if: ${{ matrix.php-versions == '7.4' }}
               run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
             - name: Update codecov.io

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -19,9 +19,10 @@ jobs:
               with:
                 php-version: ${{ matrix.php-versions }}
                 ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+                tools: parallel-lint
 
             - name: Check syntax error in sources
-              run: find ./src/ ./tests/ -type f -name '*.php' -print0 | xargs -0 -L 1 -P 4 -- php -l
+              run: parallel-lint ./src/ ./tests/
 
             - name: Install dependencies - normal
               if: ${{ matrix.php-versions != '8.2' }}

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -1,5 +1,12 @@
 name: PHP Quality Assurance
 on: [push]
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
     qa:
         runs-on: ubuntu-latest

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -18,7 +18,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                 php-version: ${{ matrix.php-versions }}
-                ini-values: error_reporting=-1, display_errors=On
+                ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
 
             - name: Check syntax error in sources
               run: find ./src/ ./tests/ -type f -name '*.php' -print0 | xargs -0 -L 1 -P 4 -- php -l

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -1,5 +1,8 @@
 name: PHP Quality Assurance
-on: [push]
+on:
+  push:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:


### PR DESCRIPTION
### GH Actions: another ini tweak

Follow up on #99: also enable assertions, which are turned off by default when using `setup-php@v2`.

### GH Actions: use PHP Parallel Lint

... for faster linting results.

Ref: https://github.com/php-parallel-lint/PHP-Parallel-Lint/

The results of PHP Parallel Lint can also be used in combination with [cs2pr](https://github.com/staabm/annotate-pull-request-from-checkstyle) to show any issues in-line in the GH (PR) code view.

### GH Actions: cache downloads for Composer

... for faster builds and to be kind to the resources which GH provides freely.

The caching is handled by using a [predefined GH action](https://github.com/marketplace/actions/install-composer-dependencies) specifically created for this purpose.
The alternative would be to handle the caching manually, which would add three extra steps to the script.

Refs:
* https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows
* https://github.com/ramsey/composer-install/

### GH Actions: selectively run tests with code coverage

As it was, the `setup-php` action would always install with `xdebug` enabled, making all PHP tasks slower and tests would always be run with code coverage being generated, while the coverage report was only used (uploaded to CodeCov) on PHP 7.4.

This commit changes that to:
* Only enable Xdebug for the PHP 7.4 build.
* Only run the tests with code coverage on PHP 7.4.

### GH Actions: run tests against highest/lowest versions of dependencies

Run tests against the highest and lowest versions of the dependencies.

To do so, this commit:
* Expands the matrix to include a new `dependency-versions` key.
    It also special cases the build against PHP 8.2, as running PHP against `lowest` won't be any use for the time being.
* Passes the new `dependency-versions` key to the `composer-install` action to allow composer to install either with `--prefer-lowest` or to install via `composer update` and get the highest available versions of dependencies.
    Ref: https://github.com/ramsey/composer-install/#dependency-versions
* Adds (extra) conditions to the linting and PHPCompat tasks as those only need to be run once per PHP version / once per build, respectively.
* Adjusts the conditions for the test runs so that the code coverage is only generated and uploaded for the `PHP 7.4 + highest` build.

### GH Actions: auto-cancel previous builds for same branch

When the same branch is pushed again (and again), builds queues can start piling up.

The configuration now added, will auto-cancel any builds from previous pushes, whether already running or still waiting.

More than anything, this is a way to be kind to GitHub by not wasting resources which they so kindly provide to us for free.

Refs:
* https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
* https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

### GH Actions: allow for manually triggering a workflow

Triggering a workflow for a branch manually is not supported by default in GH Actions, but has to be explicitly allowed.

This is useful if, for instance, an external action script or composer dependency has broken.
Once a fix is available, failing builds for open PRs can be retriggered manually instead of having to be re-pushed to retrigger the workflow.

Ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/