### PR TITLE
Composer: allow the PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,10 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is used to register external PHPCS standards with PHPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution