### PR TITLE
GH Actions: fix build

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -29,13 +29,24 @@ jobs:
         steps:
             - uses: actions/checkout@v2
 
+            - name: Determine tools
+              id: get_tools
+              run: |
+                # For running against 'lowest' PHPUnit, as well as when running against PHP 5.6 (both highest and lowest),
+                # Composer < 2.2 is needed due to bug: https://github.com/composer/composer/issues/10387
+                if [[ ${{ matrix.dependency-versions }} == "lowest" || ${{ matrix.php-versions }} == '5.6' ]]; then
+                  echo '::set-output name=TOOLS::parallel-lint, composer:v2.1'
+                else
+                  echo '::set-output name=TOOLS::parallel-lint'
+                fi
+
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
                 php-version: ${{ matrix.php-versions }}
                 ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
                 coverage: ${{ ( matrix.php-versions == '7.4' && 'xdebug' ) || 'none' }}
-                tools: parallel-lint
+                tools: ${{ steps.get_tools.outputs.TOOLS }}
 
             - name: Check syntax error in sources
               if: ${{ matrix.dependency-versions == 'highest' }}
@@ -64,6 +75,7 @@ jobs:
 
             - name: Run unit tests (without code coverage)
               if: ${{ matrix.php-versions != '7.4' || matrix.dependency-versions != 'highest' }}
+              timeout-minutes: 15
               run: ./vendor/bin/phpunit
 
             - name: Run unit tests with code coverage


### PR DESCRIPTION
Both Composer, as well as PHPUnit have released new versions to try and fix the issue with tests being run with process isolation in combination with installation via Composer 2.2, which were resulting in the following error:
```
PHPUnit\Framework\Exception: PHP Fatal error:  strict_types declaration must be the very first statement in the script in /home/runner/work/BrainMonkey/BrainMonkey/vendor/phpunit/phpunit/phpunit on line 2
```

While that fixes the builds for runs against the `highest` versions of dependencies, it still does not solve the problem when running the tests with the `lowest` dependencies (or against PHP 5.6).

Those builds now hang indefinitely.

This commit attempts to fix this by using Composer 2.1 for builds against `lowest` dependencies and against PHP 5.6.

It also sets a 15 minute time-out for the test runs against the `lowest` dependencies to prevent builds being very slow in reporting.

Refs:
* https://github.com/composer/composer/issues/10387
* https://github.com/sebastianbergmann/phpunit/pull/4846
* https://github.com/composer/composer/releases/tag/2.2.2
* https://github.com/sebastianbergmann/phpunit/blob/9.5/ChangeLog-9.5.md#9511---2021-12-25


---

Note: I will rebase the other open PRs after this PR has been merged to get their builds passing.