### PR TITLE
Refactor CI workflow

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -1,77 +1,95 @@
 name: PHP Quality Assurance
 on:
-  push:
-  # Allow manually triggering the workflow.
-  workflow_dispatch:
-
-# Cancels all previous workflow runs for the same branch that have not yet completed.
+    push:
+    pull_request:
+    workflow_dispatch:
 concurrency:
-  # The concurrency group contains the workflow name and the branch name.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-    qa:
+    static-qa:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, 'ci skip')"
-        strategy:
-            fail-fast: true
-            matrix:
-                php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
-                dependency-versions: ['lowest', 'highest']
-
-                include:
-                - php-versions: '8.2'
-                  dependency-versions: 'highest'
-
-        continue-on-error: ${{ matrix.php-versions == '8.2' }}
-
+        if: ${{ !contains(github.event.head_commit.message, 'skip qa') }}
         steps:
-            - uses: actions/checkout@v2
+            -   name: Checkout
+                uses: actions/checkout@v2
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                php-version: ${{ matrix.php-versions }}
-                ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
-                coverage: ${{ ( matrix.php-versions == '7.4' && 'xdebug' ) || 'none' }}
-                tools: parallel-lint
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 7.4
+                    coverage: none
+                    tools: cs2pr
 
-            - name: Check syntax error in sources
-              if: ${{ matrix.dependency-versions == 'highest' }}
-              run: parallel-lint ./src/ ./tests/
+            -   name: Install dependencies
+                uses: ramsey/composer-install@v2
 
-            - name: Install dependencies - normal
-              if: ${{ matrix.php-versions != '8.2' }}
-              uses: "ramsey/composer-install@v2"
-              with:
-                dependency-versions: ${{ matrix.dependency-versions }}
+            -   name: Check code styles
+                run: |
+                    ./vendor/bin/phpcs -ps . --standard=PHPCompatibility --ignore=*/vendor/* --extensions=php --basepath=./ --report-full --report-checkstyle="phpcs-report.xml" --runtime-set testVersion 5.6- --runtime-set ignore_warnings_on_exit 1
+                    cs2pr --graceful-warnings phpcs-report.xml
 
-            - name: Install dependencies - ignore-platform-reqs
-              if: ${{ matrix.php-versions == '8.2' }}
-              uses: "ramsey/composer-install@v2"
-              with:
-                dependency-versions: ${{ matrix.dependency-versions }}
-                composer-options: "--ignore-platform-reqs"
+    unit-tests:
+        runs-on: ubuntu-latest
+        if: ${{ !contains(github.event.head_commit.message, 'skip tests') }}
+        env:
+            USE_COVERAGE: 'no'
+        strategy:
+            fail-fast: false
+            matrix:
+                php-ver: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+                dependency-versions: [ 'lowest', 'highest' ]
+                experimental: [ false ]
+                include:
+                    -   php-ver: '8.2'
+                        dependency-versions: 'highest'
+                        composer-options: '--ignore-platform-reqs'
+                        experimental: true
+        continue-on-error: ${{ matrix.experimental == true }}
+        steps:
+            -   name: Update "USE_COVERAGE" env var based on matrix
+                if: ${{ matrix.php-ver == '7.4' && matrix.dependency-versions == 'highest' }}
+                run: echo "USE_COVERAGE=yes" >> $GITHUB_ENV
 
-            - name: Check cross-version PHP compatibility
-              if: ${{ matrix.php-versions == '7.4' && matrix.dependency-versions == 'highest' }} # results is same across versions, do it once
-              run: composer phpcompat
+            -   name: Checkout
+                uses: actions/checkout@v2
 
-            - name: Migrate test configuration (>= 7.3)
-              if: ${{ matrix.php-versions >= 7.3 && matrix.dependency-versions == 'highest' }}
-              run: ./vendor/bin/phpunit --migrate-configuration
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php-ver }}
+                    ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+                    coverage: ${{ ((env.USE_COVERAGE == 'yes') && 'xdebug') || 'none' }}
+                    tools: cs2pr
 
-            - name: Run unit tests (without code coverage)
-              if: ${{ matrix.php-versions != '7.4' || matrix.dependency-versions != 'highest' }}
-              run: ./vendor/bin/phpunit
+            -   name: Install parallel-lint
+                if: ${{ matrix.dependency-versions == 'highest' }}
+                run: composer require php-parallel-lint/php-parallel-lint:^1.3.1 --dev --no-update
 
-            - name: Run unit tests with code coverage
-              if: ${{ matrix.php-versions == '7.4' && matrix.dependency-versions == 'highest' }}
-              run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
+            -   name: Install dependencies
+                uses: ramsey/composer-install@v2
+                with:
+                    dependency-versions: ${{ matrix.dependency-versions }}
+                    composer-options: ${{ matrix.composer-options }}
 
-            - name: Update codecov.io
-              uses: codecov/codecov-action@v2
-              if: ${{ matrix.php-versions == '7.4' && matrix.dependency-versions == 'highest' }} # upload coverage once is enough
-              with:
-                file: ./coverage.xml
+            -   name: Lint PHP sources
+                if: ${{ matrix.dependency-versions == 'highest' }}
+                run: ./vendor/bin/parallel-lint ./src/ --checkstyle | cs2pr
+
+            -   name: Check if PHPUnit 9 is installed
+                id: phpunit_ver
+                run: echo ::set-output name=is_phpunit_9::$(composer show phpunit/phpunit | grep -E -c 'versions.+9')
+
+            -   name: Migrate PHPUnit configuration (PHPUnit 9)
+                if: ${{ steps.phpunit_ver.outputs.is_phpunit_9 != 0 }}
+                run: ./vendor/bin/phpunit --migrate-configuration
+
+            -   name: Run unit tests
+                run: ./vendor/bin/phpunit ${{ ((env.USE_COVERAGE == 'yes') && '--coverage-clover=coverage.xml') || '--no-coverage' }}
+
+            -   name: Update codecov.io
+                uses: codecov/codecov-action@v2
+                if: ${{ env.USE_COVERAGE == 'yes' }}
+                with:
+                    file: ./coverage.xml

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -90,6 +90,6 @@ jobs:
 
             -   name: Update codecov.io
                 uses: codecov/codecov-action@v2
-                if: ${{ env.USE_COVERAGE == 'yes' }}
+                if: ${{ (env.USE_COVERAGE == 'yes') && (github.ref == 'refs/heads/master') }}
                 with:
                     file: ./coverage.xml

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -79,7 +79,7 @@ jobs:
 
             -   name: Check if PHPUnit 9 is installed
                 id: phpunit_ver
-                run: echo ::set-output name=is_phpunit_9::$(composer show phpunit/phpunit | grep -E -c 'versions.+9')
+                run: echo ::set-output name=is_phpunit_9::$(composer show phpunit/phpunit | grep -E -c 'versions.+\* 9\.')
 
             -   name: Migrate PHPUnit configuration (PHPUnit 9)
                 if: ${{ steps.phpunit_ver.outputs.is_phpunit_9 != 0 }}

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -79,7 +79,7 @@ jobs:
 
             -   name: Check if PHPUnit 9 is installed
                 id: phpunit_ver
-                run: echo ::set-output name=is_phpunit_9::$(composer show phpunit/phpunit | grep -E -c 'versions.+\* 9\.')
+                run: echo ::set-output name=is_phpunit_9::$(./vendor/bin/phpunit --version | grep -c '9\.')
 
             -   name: Migrate PHPUnit configuration (PHPUnit 9)
                 if: ${{ steps.phpunit_ver.outputs.is_phpunit_9 != 0 }}

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -90,6 +90,6 @@ jobs:
 
             -   name: Update codecov.io
                 uses: codecov/codecov-action@v2
-                if: ${{ (env.USE_COVERAGE == 'yes') && (github.ref == 'refs/heads/master') }}
+                if: ${{ env.USE_COVERAGE == 'yes' }}
                 with:
                     file: ./coverage.xml


### PR DESCRIPTION
- "Static" QA, which doesn't need to run on multiple PHP versions, is now executed in a separate job, instead of relying on a condition. The idea is in future to use the same job to run a static analizer like Psalm.
- QA checks are also executed on pull requests
- The `"ci skip"` in the commit message is now *natively* supported by GitHub actions. So I'm using two different messages to skip "selectively" the two jobs: `"skip qa"`  to skip static analysis, and  `"skip tests"`  to skip unit tests
- Both jobs (static qa & unit tests) use `cs2pr` to format output.
- An env variable `USE_COVERAGE` is used to determine if coverage should be used or not. That simplify the checks in various steps.
- The two "install dependencies" steps (one ignoring platform reqs, the other not), are merged in one, using a matrix variable to make that distinction
- The condition to migrate configuration for PHPUnit is not anymore based on PHP version and other matrix variables, but instead by checking PHPUnit version "grepping" the output `composer show phpunit/phpunit`: we now migrate configuration if PHPUnit is in version 9.
- The two steps to run unit tests (with and without coverage) are now merged into one, using an "inline" condition in the command (easier now that we have `USE_COVERAGE` env var)
- The update of codecov.io only happens when pushing on master: does not really make sense to update it in other branches of for pull requests

Note: somewhere else I had issues with the "parallel lint" phar installed via the "setup-php" action: sometimes it installs a version that is not compatible with PHP 8.1. That is why here I'm installing the tool via Composer, ensuring latest version is installed.