### PR TITLE
GH Actions: version update for codecov action runner

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -71,7 +71,7 @@ jobs:
               run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
             - name: Update codecov.io
-              uses: codecov/codecov-action@v2
+              uses: codecov/codecov-action@v3
               if: ${{ matrix.php-versions == '7.4' && matrix.dependency-versions == 'highest' }} # upload coverage once is enough
               with:
                 file: ./coverage.xml


### PR DESCRIPTION
Yet another predefined action has had a major release.

This is, again, mostly just a change of the Node version used by the action itself (from Node 12 to Node 16).

Refs:
* https://github.com/codecov/codecov-action/releases