### PR TITLE
GH Actions: various tweaks / PHP 8.2 not allowed to fail

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -46,8 +46,8 @@ jobs:
               uses: "ramsey/composer-install@v2"
               with:
                 dependency-versions: ${{ matrix.dependency-versions }}
-                # Bust the cache at least once a month - output format: YYYY-MM-DD.
-                custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+                # Bust the cache at least once a month - output format: YYYY-MM.
+                custom-cache-suffix: $(date -u "+%Y-%m")
 
             - name: Install dependencies - ignore-platform-reqs
               if: ${{ matrix.php-versions == '8.2' }}
@@ -55,7 +55,7 @@ jobs:
               with:
                 dependency-versions: ${{ matrix.dependency-versions }}
                 composer-options: "--ignore-platform-reqs"
-                custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+                custom-cache-suffix: $(date -u "+%Y-%m")
 
             - name: Check cross-version PHP compatibility
               if: ${{ matrix.php-versions == '7.4' && matrix.dependency-versions == 'highest' }} # results is same across versions, do it once

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -17,14 +17,14 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+                php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
                 dependency-versions: ['lowest', 'highest']
 
                 include:
-                - php-versions: '8.2'
+                - php-versions: '8.3'
                   dependency-versions: 'highest'
 
-        continue-on-error: ${{ matrix.php-versions == '8.2' }}
+        continue-on-error: ${{ matrix.php-versions == '8.3' }}
 
         steps:
             - uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
               run: parallel-lint ./src/ ./tests/
 
             - name: Install dependencies - normal
-              if: ${{ matrix.php-versions != '8.2' }}
+              if: ${{ matrix.php-versions != '8.3' }}
               uses: "ramsey/composer-install@v2"
               with:
                 dependency-versions: ${{ matrix.dependency-versions }}
@@ -50,7 +50,7 @@ jobs:
                 custom-cache-suffix: $(date -u "+%Y-%m")
 
             - name: Install dependencies - ignore-platform-reqs
-              if: ${{ matrix.php-versions == '8.2' }}
+              if: ${{ matrix.php-versions == '8.3' }}
               uses: "ramsey/composer-install@v2"
               with:
                 dependency-versions: ${{ matrix.dependency-versions }}


### PR DESCRIPTION
### GH Actions: minor simplification

... of the bash `date` command in the earlier pulled cache busting.

### GH Actions: update PHP versions in workflows

PHP 8.2 has been released today 🎉 and the `setup-php` action has announced support for PHP 8.3, so adding PHP 8.3 to the matrix and no longer allowing PHP 8.2 to fail the build.

Builds against PHP 8.3 are still allowed to fail for now.