### PR TITLE
Predefined functions enhancements

### DIFF
--- a/docs/wordpress-specific-tools/wordpress-tools.md
+++ b/docs/wordpress-specific-tools/wordpress-tools.md
@@ -45,6 +45,8 @@ Following functions are defined by Brain Monkey when it is loaded for tests:
 * `absint()` \(since 2.3\)
 * `wp_json_encode()` \(since 2.6\)
 * `is_wp_error()` \(since 2.3\)
+* `wp_validate_boolean()` \(since 2.7\)
+* `wp_slash()` \(since 2.7\)
 
 **Translation function:**
 

--- a/inc/wp-helper-functions.php
+++ b/inc/wp-helper-functions.php
@@ -108,3 +108,12 @@ if ( ! function_exists('wp_validate_boolean')) {
     }
 }
 
+if ( ! function_exists('wp_slash')) {
+    function wp_slash($value)
+    {
+        if (is_array($value)) {
+            return array_map('wp_slash', $value);
+        }
+        return is_string($value) ? addslashes($value) : $value;
+    }
+}

--- a/inc/wp-helper-functions.php
+++ b/inc/wp-helper-functions.php
@@ -100,3 +100,11 @@ if ( ! function_exists('is_wp_error')) {
         return $thing instanceof \WP_Error;
     }
 }
+
+if ( ! function_exists('wp_validate_boolean')) {
+    function wp_validate_boolean($var)
+    {
+        return (is_string($var) && (strtolower($var) === 'false')) ? false : (bool)$var;
+    }
+}
+

--- a/tests/cases/functional/FunctionsTest.php
+++ b/tests/cases/functional/FunctionsTest.php
@@ -53,12 +53,9 @@ class FunctionsTest extends FunctionalTestCase
         static::assertTrue(is_wp_error($error));
         static::assertFalse(is_wp_error('x'));
 
-        static::assertTrue(is_bool(wp_validate_boolean(true)));
-        static::assertTrue(is_bool(wp_validate_boolean(false)));
-        static::assertTrue(is_bool(wp_validate_boolean(1)));
-        static::assertTrue(is_bool(wp_validate_boolean('lorem ipsum')));
         static::assertTrue(wp_validate_boolean(true));
         static::assertFalse(wp_validate_boolean(false));
+        static::assertFalse(wp_validate_boolean('false'));
         static::assertTrue(wp_validate_boolean(1));
         static::assertTrue(wp_validate_boolean('lorem ipsum'));
     }

--- a/tests/cases/functional/FunctionsTest.php
+++ b/tests/cases/functional/FunctionsTest.php
@@ -58,6 +58,12 @@ class FunctionsTest extends FunctionalTestCase
         static::assertFalse(wp_validate_boolean('false'));
         static::assertTrue(wp_validate_boolean(1));
         static::assertTrue(wp_validate_boolean('lorem ipsum'));
+
+        static::assertSame('foo', wp_slash('foo'));
+        static::assertSame(1, wp_slash(1));
+        static::assertSame(['foo', 2, 'bar'], wp_slash(['foo', 2, 'bar']));
+        static::assertSame('L\\\'x\\"y', wp_slash('L\'x"y'));
+        static::assertSame(['L\\\'x\\"y', 'bar'], wp_slash(['L\'x"y', 'bar']));
     }
 
     public function testReDefinePredefinedStubsWithWhen()


### PR DESCRIPTION
Add stubs for `wp_validate_boolean()` and `wp_slash()`.

See #125 