### PR TITLE
Stub _n_noop, _nx_noop, translate_nooped_plural

### DIFF
--- a/docs/functions-testing-tools/function-stubs.md
+++ b/docs/functions-testing-tools/function-stubs.md
@@ -134,6 +134,9 @@ When called, it will create a stub for _all_ the following functions:
 * `esc_attr_x()` 
 * `esc_html_e()` 
 * `esc_attr_e()` 
+* `_n_noop()` \(since 2.7\)
+* `_nx_noop()` \(since 2.7\)
+* `translate_nooped_plural()` \(since 2.7\)
 
 The created stub will not attempt any translation, but will return \(or echo\) the first received argument.
 

--- a/inc/api.php
+++ b/inc/api.php
@@ -155,6 +155,15 @@ namespace Brain\Monkey\Functions {
                 'esc_attr_x' => [EscapeHelper::class, 'esc'],
                 'esc_html_e' => [EscapeHelper::class, 'escAndEcho'],
                 'esc_attr_e' => [EscapeHelper::class, 'escAndEcho'],
+                '_n_noop'    => static function ($singular, $plural) {
+                    return compact('singular', 'plural');
+                },
+                '_nx_noop' => static function ($singular, $plural) {
+                    return compact('singular', 'plural');
+                },
+                'translate_nooped_plural' => static function($nooped, $number) {
+                    return ($number === 1) ? $nooped['singular'] : $nooped['plural'];
+                },
             ]
         );
 


### PR DESCRIPTION
Stub for `_n_noop()`, `_nx_noop()`, and `translate_nooped_plural()` were missing in `stubTranslationFunctions()`

See #51