### PR TITLE
WP Helper functions: ensure parameter names are in line with WP Core

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -161,8 +161,8 @@ namespace Brain\Monkey\Functions {
                 '_nx_noop' => static function ($singular, $plural) {
                     return compact('singular', 'plural');
                 },
-                'translate_nooped_plural' => static function($nooped, $number) {
-                    return ($number === 1) ? $nooped['singular'] : $nooped['plural'];
+                'translate_nooped_plural' => static function($nooped_plural, $count) {
+                    return ($count === 1) ? $nooped_plural['singular'] : $nooped_plural['plural'];
                 },
             ]
         );

--- a/inc/wp-helper-functions.php
+++ b/inc/wp-helper-functions.php
@@ -60,30 +60,30 @@ if ( ! function_exists('__return_empty_string')) {
 }
 
 if ( ! function_exists('untrailingslashit')) {
-    function untrailingslashit($string)
+    function untrailingslashit($value)
     {
-        return rtrim($string, '/\\');
+        return rtrim($value, '/\\');
     }
 }
 
 if ( ! function_exists('trailingslashit')) {
-    function trailingslashit($string)
+    function trailingslashit($value)
     {
-        return rtrim($string, '/\\').'/';
+        return rtrim($value, '/\\').'/';
     }
 }
 
 if ( ! function_exists('user_trailingslashit')) {
-    function user_trailingslashit($string)
+    function user_trailingslashit($url)
     {
-        return trailingslashit($string);
+        return trailingslashit($url);
     }
 }
 
 if ( ! function_exists('absint')) {
-    function absint($number)
+    function absint($maybeint)
     {
-        return abs((int)$number);
+        return abs((int)$maybeint);
     }
 }
 
@@ -102,9 +102,9 @@ if ( ! function_exists('is_wp_error')) {
 }
 
 if ( ! function_exists('wp_validate_boolean')) {
-    function wp_validate_boolean($var)
+    function wp_validate_boolean($value)
     {
-        return (is_string($var) && (strtolower($var) === 'false')) ? false : (bool)$var;
+        return (is_string($value) && (strtolower($value) === 'false')) ? false : (bool)$value;
     }
 }
 

--- a/inc/wp-hook-functions.php
+++ b/inc/wp-hook-functions.php
@@ -15,144 +15,144 @@
 use Brain\Monkey;
 
 if ( ! function_exists('add_action')) {
-    function add_action($action, $function, $priority = 10, $accepted_args = 1)
+    function add_action($hook_name, $callback, $priority = 10, $accepted_args = 1)
     {
-        $args = [$function, $priority, $accepted_args];
+        $args = [$callback, $priority, $accepted_args];
         $container = Monkey\Container::instance();
-        $container->hookStorage()->pushToAdded(Monkey\Hook\HookStorage::ACTIONS, $action, $args);
-        $container->hookExpectationExecutor()->executeAddAction($action, $args);
+        $container->hookStorage()->pushToAdded(Monkey\Hook\HookStorage::ACTIONS, $hook_name, $args);
+        $container->hookExpectationExecutor()->executeAddAction($hook_name, $args);
 
         return true;
     }
 }
 
 if ( ! function_exists('add_filter')) {
-    function add_filter($filter, $function, $priority = 10, $accepted_args = 1)
+    function add_filter($hook_name, $callback, $priority = 10, $accepted_args = 1)
     {
-        $args = [$function, $priority, $accepted_args];
+        $args = [$callback, $priority, $accepted_args];
         $container = Monkey\Container::instance();
-        $container->hookStorage()->pushToAdded(Monkey\Hook\HookStorage::FILTERS, $filter, $args);
-        $container->hookExpectationExecutor()->executeAddFilter($filter, $args);
+        $container->hookStorage()->pushToAdded(Monkey\Hook\HookStorage::FILTERS, $hook_name, $args);
+        $container->hookExpectationExecutor()->executeAddFilter($hook_name, $args);
 
         return true;
     }
 }
 
 if ( ! function_exists('do_action')) {
-    function do_action($action, ...$args)
+    function do_action($hook_name, ...$args)
     {
         $container = Monkey\Container::instance();
-        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::ACTIONS, $action, $args);
-        $container->hookExpectationExecutor()->executeDoAction($action, $args);
+        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::ACTIONS, $hook_name, $args);
+        $container->hookExpectationExecutor()->executeDoAction($hook_name, $args);
     }
 }
 
 if ( ! function_exists('do_action_ref_array')) {
-    function do_action_ref_array($action, array $args)
+    function do_action_ref_array($hook_name, array $args)
     {
         $container = Monkey\Container::instance();
-        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::ACTIONS, $action, $args);
-        $container->hookExpectationExecutor()->executeDoAction($action, $args);
+        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::ACTIONS, $hook_name, $args);
+        $container->hookExpectationExecutor()->executeDoAction($hook_name, $args);
     }
 }
 
 if ( ! function_exists('do_action_deprecated')) {
-    function do_action_deprecated($action, array $args, $version, $replacement, $message = null)
+    function do_action_deprecated($hook_name, array $args, $version, $replacement, $message = null)
     {
         $container = Monkey\Container::instance();
-        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::ACTIONS, $action, $args);
-        $container->hookExpectationExecutor()->executeDoAction($action, $args);
+        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::ACTIONS, $hook_name, $args);
+        $container->hookExpectationExecutor()->executeDoAction($hook_name, $args);
     }
 }
 
 if ( ! function_exists('apply_filters')) {
-    function apply_filters($filter, ...$args)
+    function apply_filters($hook_name, ...$args)
     {
         $container = Monkey\Container::instance();
-        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::FILTERS, $filter, $args);
+        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::FILTERS, $hook_name, $args);
 
-        return $container->hookExpectationExecutor()->executeApplyFilters($filter, $args);
+        return $container->hookExpectationExecutor()->executeApplyFilters($hook_name, $args);
     }
 }
 
 if ( ! function_exists('apply_filters_ref_array')) {
-    function apply_filters_ref_array($filter, array $args)
+    function apply_filters_ref_array($hook_name, array $args)
     {
         $container = Monkey\Container::instance();
-        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::FILTERS, $filter, $args);
+        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::FILTERS, $hook_name, $args);
 
-        return $container->hookExpectationExecutor()->executeApplyFilters($filter, $args);
+        return $container->hookExpectationExecutor()->executeApplyFilters($hook_name, $args);
     }
 }
 
 if ( ! function_exists('apply_filters_deprecated')) {
-    function apply_filters_deprecated($filter, array $args, $version, $replacement, $message = null)
+    function apply_filters_deprecated($hook_name, array $args, $version, $replacement, $message = null)
     {
         $container = Monkey\Container::instance();
-        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::FILTERS, $filter, $args);
+        $container->hookStorage()->pushToDone(Monkey\Hook\HookStorage::FILTERS, $hook_name, $args);
 
-        return $container->hookExpectationExecutor()->executeApplyFilters($filter, $args);
+        return $container->hookExpectationExecutor()->executeApplyFilters($hook_name, $args);
     }
 }
 
 if ( ! function_exists('has_action')) {
-    function has_action($action, $callback = null)
+    function has_action($hook_name, $callback = null)
     {
-        return Monkey\Actions\has($action, $callback);
+        return Monkey\Actions\has($hook_name, $callback);
     }
 }
 
 if ( ! function_exists('has_filter')) {
-    function has_filter($filter, $callback = null)
+    function has_filter($hook_name, $callback = null)
     {
-        return Monkey\Filters\has($filter, $callback);
+        return Monkey\Filters\has($hook_name, $callback);
     }
 }
 
 if ( ! function_exists('did_action')) {
-    function did_action($action)
+    function did_action($hook_name)
     {
-        return Monkey\Actions\did($action);
+        return Monkey\Actions\did($hook_name);
     }
 }
 
 if ( ! function_exists('remove_action')) {
-    function remove_action($action, $function, $priority = 10)
+    function remove_action($hook_name, $callback, $priority = 10)
     {
         $container = Monkey\Container::instance();
         $storage = $container->hookStorage();
-        $args = [$function, $priority];
+        $args = [$callback, $priority];
 
-        $container->hookExpectationExecutor()->executeRemoveAction($action, $args);
+        $container->hookExpectationExecutor()->executeRemoveAction($hook_name, $args);
 
-        return $storage->removeFromAdded(Monkey\Hook\HookStorage::ACTIONS, $action, $args);
+        return $storage->removeFromAdded(Monkey\Hook\HookStorage::ACTIONS, $hook_name, $args);
     }
 }
 
 if ( ! function_exists('remove_filter')) {
-    function remove_filter($filter, $function, $priority = 10)
+    function remove_filter($hook_name, $callback, $priority = 10)
     {
         $container = Monkey\Container::instance();
         $storage = $container->hookStorage();
-        $args = [$function, $priority];
+        $args = [$callback, $priority];
 
-        $container->hookExpectationExecutor()->executeRemoveFilter($filter, $args);
+        $container->hookExpectationExecutor()->executeRemoveFilter($hook_name, $args);
 
-        return $storage->removeFromAdded(Monkey\Hook\HookStorage::FILTERS, $filter, $args);
+        return $storage->removeFromAdded(Monkey\Hook\HookStorage::FILTERS, $hook_name, $args);
     }
 }
 
 if ( ! function_exists('doing_action')) {
-    function doing_action($action)
+    function doing_action($hook_name)
     {
-        return Monkey\Actions\doing($action);
+        return Monkey\Actions\doing($hook_name);
     }
 }
 
 if ( ! function_exists('doing_filter')) {
-    function doing_filter($filter)
+    function doing_filter($hook_name)
     {
-        return Monkey\Filters\doing($filter);
+        return Monkey\Filters\doing($hook_name);
     }
 }
 


### PR DESCRIPTION
... for compatibility with code under test using PHP 8.0+ function calls with named arguments.

For some of these functions, WP has renamed the parameter(s) over the past year or so, for some, the names were never in line.

Even though WP Core doesn't necessarily officially _support_ the use of named parameters in function calls, that (of course) won't stop people from using them and their tests should not break on that due to BrainMonkey not being in line with WP for parameter names.