### PR TITLE
PHP 8.4 | Fix implicitly nullable parameter

### DIFF
--- a/src/Expectation/Expectation.php
+++ b/src/Expectation/Expectation.php
@@ -96,16 +96,16 @@ class Expectation
     /**
      * @param \Mockery\ExpectationInterface               $expectation
      * @param \Brain\Monkey\Expectation\ExpectationTarget $target
-     * @param \ArrayAccess                                $return_expectations
+     * @param \ArrayAccess|null                           $return_expectations
      */
     public function __construct(
         ExpectationInterface $expectation,
         ExpectationTarget $target,
-        \ArrayAccess $return_expectations = null
+        $return_expectations = null
     ) {
         $this->expectation = $expectation;
         $this->target = $target;
-        $this->return_expectations = $return_expectations ? : new \ArrayObject();
+        $this->return_expectations = ($return_expectations instanceof \ArrayAccess) ? $return_expectations : new \ArrayObject();
     }
 
     /**


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters, i.e. typed parameter with a `null` default value, which are not explicitly declared as nullable.

This commit fixes the one instance found in this codebase.

Includes updating the documentation to match.

Note: while this is not a `final` class and the change is effectively a change to the method signature, this is not a BC break as (overloaded) constructors are exempt from signature checks.

Ref: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types