### PR TITLE
PHP 8.4 | Fix passing `E_USER_ERROR` to `trigger_error()`

### DIFF
--- a/src/Expectation/Exception/MissingFunctionExpectations.php
+++ b/src/Expectation/Exception/MissingFunctionExpectations.php
@@ -1,0 +1,21 @@
+<?php # -*- coding: utf-8 -*-
+/*
+ * This file is part of the BrainMonkey package.
+ *
+ * (c) Giuseppe Mazzapica
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Brain\Monkey\Expectation\Exception;
+
+/**
+ * @author  Giuseppe Mazzapica <giuseppe.mazzapica@gmail.com>
+ * @package BrainMonkey
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+class MissingFunctionExpectations extends Exception
+{
+
+}

--- a/src/Expectation/FunctionStub.php
+++ b/src/Expectation/FunctionStub.php
@@ -42,9 +42,8 @@ class FunctionStub
         $function = <<<PHP
 namespace {$namespace} {
     function {$name}() {
-        trigger_error(
-            '"{$name}" is not defined nor mocked in this test.',
-            E_USER_ERROR
+        throw new \Brain\Monkey\Expectation\Exception\MissingFunctionExpectations(
+            '"{$name}" is not defined nor mocked in this test.'
         );
      }
 }

--- a/tests/cases/unit/Api/FunctionsTest.php
+++ b/tests/cases/unit/Api/FunctionsTest.php
@@ -10,6 +10,7 @@
 
 namespace Brain\Monkey\Tests\Unit\Api;
 
+use Brain\Monkey\Expectation\Exception\MissingFunctionExpectations;
 use Brain\Monkey\Functions;
 use Brain\Monkey\Tests\UnitTestCase;
 use Mockery\Exception\InvalidCountException;
@@ -146,53 +147,53 @@ class FunctionsTest extends UnitTestCase
         i_do_not_exists('Cool!');
     }
 
-    public function testUndefinedFunctionTriggerErrorRightAfterDefinition()
+    public function testUndefinedFunctionThrowsExceptionRightAfterDefinition()
     {
-        $this->expectErrorException();
-        Functions\when('since_i_am_not_defined_i_will_trigger_error');
-        $this->expectExceptionMsgRegex('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
+        $this->expectException(MissingFunctionExpectations::class);
+        Functions\when('since_i_am_not_defined_i_will_throw_exception');
+        $this->expectExceptionMsgRegex('/since_i_am_not_defined_i_will_throw_exception.+not defined/');
         /** @noinspection PhpUndefinedFunctionInspection */
-        since_i_am_not_defined_i_will_trigger_error();
+        since_i_am_not_defined_i_will_throw_exception();
     }
 
     /**
-     * @depends testUndefinedFunctionTriggerErrorRightAfterDefinition
+     * @depends testUndefinedFunctionThrowsExceptionRightAfterDefinition
      */
     public function testUndefinedFunctionSurviveTests()
     {
-        static::assertTrue(function_exists('since_i_am_not_defined_i_will_trigger_error'));
+        static::assertTrue(function_exists('since_i_am_not_defined_i_will_throw_exception'));
     }
 
     /**
      * @depends testUndefinedFunctionSurviveTests
      */
-    public function testSurvivedFunctionStillTriggerError()
+    public function testSurvivedFunctionStillThrowsException()
     {
-        $this->expectErrorException();
-        $this->expectExceptionMsgRegex('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
+        $this->expectException(MissingFunctionExpectations::class);
+        $this->expectExceptionMsgRegex('/since_i_am_not_defined_i_will_throw_exception.+not defined/');
         /** @noinspection PhpUndefinedFunctionInspection */
-        since_i_am_not_defined_i_will_trigger_error();
+        since_i_am_not_defined_i_will_throw_exception();
     }
 
     /**
-     * @depends testSurvivedFunctionStillTriggerError
+     * @depends testSurvivedFunctionStillThrowsException
      */
     public function testNothingJustMockASurvivedFunction()
     {
-        Functions\when('since_i_am_not_defined_i_will_trigger_error')->justReturn(1234567890);
+        Functions\when('since_i_am_not_defined_i_will_throw_exception')->justReturn(1234567890);
         /** @noinspection PhpUndefinedFunctionInspection */
-        static::assertSame(1234567890, since_i_am_not_defined_i_will_trigger_error());
+        static::assertSame(1234567890, since_i_am_not_defined_i_will_throw_exception());
     }
 
     /**
      * @depends testNothingJustMockASurvivedFunction
      */
-    public function testSurvivedFunctionStillTriggerErrorAfterBeingMocked()
+    public function testSurvivedFunctionStillThrowsExceptionAfterBeingMocked()
     {
-        $this->expectErrorException();
-        $this->expectExceptionMsgRegex('/since_i_am_not_defined_i_will_trigger_error.+not defined/');
+        $this->expectException(MissingFunctionExpectations::class);
+        $this->expectExceptionMsgRegex('/since_i_am_not_defined_i_will_throw_exception.+not defined/');
         /** @noinspection PhpUndefinedFunctionInspection */
-        since_i_am_not_defined_i_will_trigger_error();
+        since_i_am_not_defined_i_will_throw_exception();
     }
 
     public function testAndAlsoExpectIt()


### PR DESCRIPTION
PHP 8.4 deprecates passing `E_USER_ERROR` to `trigger_error()`, with the recommendation being to replace these type of calls with either an Exception or an `exit` statement.

This commit fixes the one instance found in this codebase by introducing a new `MissingFunctionExpectations` exception.

Includes updating the related tests (and test names) to match.

Ref: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error

Related to #146