### PR TITLE
Composer: update the PHPCS Composer installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7.26 || ^6.0 || ^7.0 || >=8.0 <8.5.12 || ^8.5.14 || ^9.0",
         "phpcompatibility/php-compatibility": "^9.3.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1"
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
... for which the 1.0 version was released over two years ago.

Refs:
* https://github.com/PHPCSStandards/composer-installer/releases/tag/v1.0.0