### PR TITLE
GH Actions: update for the release of PHP 8.5

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -25,8 +25,10 @@ jobs:
                   dependency-versions: 'highest'
                 - php-versions: '8.5'
                   dependency-versions: 'highest'
+                - php-versions: '8.6'
+                  dependency-versions: 'highest'
 
-        continue-on-error: ${{ matrix.php-versions == '8.5' }}
+        continue-on-error: ${{ matrix.php-versions == '8.6' }}
 
         steps:
             - uses: actions/checkout@v5
@@ -45,20 +47,13 @@ jobs:
               if: ${{ matrix.dependency-versions == 'highest' }}
               run: parallel-lint ./src/ ./tests/
 
-            - name: Install dependencies - normal
-              if: ${{ matrix.php-versions != '8.5' }}
+            - name: Install dependencies
               uses: "ramsey/composer-install@v3"
               with:
                 dependency-versions: ${{ matrix.dependency-versions }}
+                # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
+                composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }}
                 # Bust the cache at least once a month - output format: YYYY-MM.
-                custom-cache-suffix: $(date -u "+%Y-%m")
-
-            - name: Install dependencies - ignore-platform-reqs
-              if: ${{ matrix.php-versions == '8.5' }}
-              uses: "ramsey/composer-install@v3"
-              with:
-                dependency-versions: ${{ matrix.dependency-versions }}
-                composer-options: "--ignore-platform-reqs"
                 custom-cache-suffix: $(date -u "+%Y-%m")
 
             - name: Check cross-version PHP compatibility


### PR DESCRIPTION
... which is expected to be released this Thursday.

* Builds against PHP 8.5 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.6.
* Includes minor workflow step logic simplifcation.

Note (same as [last year](https://github.com/Brain-WP/BrainMonkey/pull/152)): running PHP 8.4 with dependencies: lowest will not work due to issues in Patchwork and Mockery, but raising the minimum versions of those dependencies would require dropping support for PHP < 7.1 (and maybe more).

Then again... might be about time to drop support for PHP < 7.2 ? WP itself has had a PHP 7.2 minimum for a while now.