### PR TITLE
CS: start using PHPCompatibility 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.52 || ^9.6.34",
-        "phpcompatibility/php-compatibility": "^9.3.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0"
+        "phpcompatibility/php-compatibility": "^10.0.0@alpha"
     },
     "autoload": {
         "psr-4": {

--- a/tests/cases/unit/Api/FunctionsTest.php
+++ b/tests/cases/unit/Api/FunctionsTest.php
@@ -363,6 +363,7 @@ class FunctionsTest extends UnitTestCase
         Functions\stubEscapeFunctions();
 
         $lorem = '<b>Lorem ipsum</b>';
+        // phpcs:ignore PHPCompatibility.ParameterValues.NewHTMLEntitiesFlagsDefault.NotSet -- This is deliberate as WP doesn't set the parameter.
         $escaped = htmlspecialchars($lorem);
 
         static::assertSame($escaped, esc_html($lorem));


### PR DESCRIPTION
Long anticipated, finally here: PHPCompatibility 10.0.0-alpha1/alpha2 :tada:

PHPCompatibility 10.0.0 brings huge improvements in both what is being detected (> 50 new sniffs), as well as the detection accuracy for pre-existing sniffs.

Even though still "unstable", it is stable enough for our purposes and the advantages of using it outweigh the disadvantage of it being an unstable version. By setting the `minimum-stability` and `prefer-stable` settings in the `composer.json`, we can ensure that we don't get the `dev-develop` branch, but rather get a `10.0.0` tag, unstable or not.

And what with the improved detection, a number of php incompatibilities previously not flagged, are now flagged, even though we already handle them correctly via conditions. So this commit also adds a few selective ignore comments for those few situations where they are needed.

Includes adding one ignore annotation.

Ref:
* https://github.com/PHPCompatibility/PHPCompatibility/wiki/Upgrading-to-PHPCompatibility-10.0
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/10.0.0-alpha1
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/10.0.0-alpha2